### PR TITLE
Handle Boolean "support" and Boolean and date "discontinued"

### DIFF
--- a/src/norwegianblue/__init__.py
+++ b/src/norwegianblue/__init__.py
@@ -168,10 +168,11 @@ def _colourify(data: list[dict]) -> list[dict]:
                 continue
 
             if isinstance(cycle[property_], bool):
-                if property_ == "eol" and cycle["eol"]:
-                    cycle["eol"] = colored(cycle["eol"], "red")
-                else:
-                    cycle["eol"] = colored(cycle["eol"], "green")
+                if property_ == "support":
+                    colour = "green" if cycle["support"] else "red"
+                else:  # "eol"
+                    colour = "red" if cycle["eol"] else "green"
+                cycle[property_] = colored(cycle[property_], colour)
                 continue
 
             date_str = cycle[property_]

--- a/src/norwegianblue/__init__.py
+++ b/src/norwegianblue/__init__.py
@@ -163,18 +163,20 @@ def _colourify(data: list[dict]) -> list[dict]:
     six_months_from_now = now + relativedelta(months=+6)
 
     for cycle in data:
-        for property_ in ("support", "eol"):
+        for property_ in ("support", "eol", "discontinued"):
             if property_ not in cycle:
                 continue
 
+            # Handle Boolean
             if isinstance(cycle[property_], bool):
                 if property_ == "support":
                     colour = "green" if cycle["support"] else "red"
-                else:  # "eol"
-                    colour = "red" if cycle["eol"] else "green"
+                else:  # "eol" and "discontinued"
+                    colour = "red" if cycle[property_] else "green"
                 cycle[property_] = colored(cycle[property_], colour)
                 continue
 
+            # Handle date
             date_str = cycle[property_]
             # Convert "2020-01-01" string to datetime
             date_datetime = dt.datetime.strptime(date_str, "%Y-%m-%d")
@@ -205,7 +207,7 @@ def _tabulate(data: list[dict], format: str = "markdown") -> str:
     writer.value_matrix = data
 
     # Put headers in preferred order, with the rest at the end
-    preferred_order = ["cycle", "latest", "release", "support", "eol"]
+    preferred_order = ["cycle", "latest", "release", "support", "discontinued", "eol"]
     new_headers = []
     for preferred in preferred_order:
         if preferred in headers:

--- a/tests/test_norwegianblue.py
+++ b/tests/test_norwegianblue.py
@@ -260,3 +260,78 @@ class TestNorwegianBlue:
 
         # Assert
         assert output == expected
+
+    def test__colourify_boolean_discontinued(self):
+        # Arrange
+        data = [
+            {
+                "cycle": "iPhone 5C",
+                "discontinued": "2025-09-09",
+                "eol": True,
+            },
+            {
+                "cycle": "iPhone 5S",
+                "discontinued": "2016-03-21",
+                "eol": True,
+            },
+            {
+                "cycle": "iPhone 6S / 6S Plus",
+                "discontinued": "2018-09-12",
+                "eol": False,
+            },
+            {
+                "cycle": "iPhone XR",
+                "discontinued": False,
+                "eol": False,
+            },
+            {
+                "cycle": "iPhone 11 Pro / 11 Pro Max",
+                "discontinued": "2020-10-13",
+                "eol": False,
+            },
+            {
+                "cycle": "iPhone 12 Mini / 12 Pro Max",
+                "discontinued": True,
+                "eol": False,
+            },
+        ]
+
+        expected = [
+            {
+                "cycle": "iPhone 5C",
+                "discontinued": "\x1b[32m2025-09-09\x1b[0m",  # green
+                "eol": "\x1b[31mTrue\x1b[0m",  # red
+            },
+            {
+                "cycle": "iPhone 5S",
+                "discontinued": "\x1b[31m2016-03-21\x1b[0m",  # red
+                "eol": "\x1b[31mTrue\x1b[0m",  # red
+            },
+            {
+                "cycle": "iPhone 6S / 6S Plus",
+                "discontinued": "\x1b[31m2018-09-12\x1b[0m",  # red
+                "eol": "\x1b[32mFalse\x1b[0m",  # green
+            },
+            {
+                "cycle": "iPhone XR",
+                "discontinued": "\x1b[32mFalse\x1b[0m",  # red
+                "eol": "\x1b[32mFalse\x1b[0m",  # green
+            },
+            {
+                "cycle": "iPhone 11 Pro / 11 Pro Max",
+                "discontinued": "\x1b[31m2020-10-13\x1b[0m",  # red
+                "eol": "\x1b[32mFalse\x1b[0m",  # green
+            },
+            {
+                "cycle": "iPhone 12 Mini / 12 Pro Max",
+                "discontinued": "\x1b[31mTrue\x1b[0m",  # red
+                "eol": "\x1b[32mFalse\x1b[0m",  # green
+            },
+        ]
+
+        # Act
+        output = norwegianblue._colourify(data)
+        print(output)
+
+        # Assert
+        assert output == expected

--- a/tests/test_norwegianblue.py
+++ b/tests/test_norwegianblue.py
@@ -199,6 +199,49 @@ class TestNorwegianBlue:
         # Assert
         assert output == expected
 
+    def test__colourify_boolean_support(self):
+        # Arrange
+        data = [
+            {
+                "cycle": "5.x",
+                "eol": False,
+                "support": True,
+            },
+            {
+                "cycle": "4.x",
+                "eol": "2022-11-01",
+                "support": False,
+            },
+            {
+                "cycle": "3.x",
+                "eol": "2019-07-24",
+                "support": False,
+            },
+        ]
+        expected = [
+            {
+                "cycle": "5.x",
+                "eol": "\x1b[32mFalse\x1b[0m",  # green
+                "support": "\x1b[32mTrue\x1b[0m",  # green
+            },
+            {
+                "cycle": "4.x",
+                "eol": "\x1b[32m2022-11-01\x1b[0m",  # green
+                "support": "\x1b[31mFalse\x1b[0m",  # red
+            },
+            {
+                "cycle": "3.x",
+                "eol": "\x1b[31m2019-07-24\x1b[0m",  # red
+                "support": "\x1b[31mFalse\x1b[0m",  # red
+            },
+        ]
+
+        # Act
+        output = norwegianblue._colourify(data)
+
+        # Assert
+        assert output == expected
+
     def test__colourify_boolean_eol(self):
         # Arrange
         data = [
@@ -214,7 +257,6 @@ class TestNorwegianBlue:
 
         # Act
         output = norwegianblue._colourify(data)
-        print(output)
 
         # Assert
         assert output == expected


### PR DESCRIPTION
Like https://github.com/hugovk/norwegianblue/pull/2, `support` can be either a date or Boolean:

`eol bootstrap`

|  cycle  | latest |  release   | support |    eol     |
| ------- | ------ | ---------- | ------- | ---------- |
| 5.x LTS | 5.0.1  | 2021-05-05 | True    | False      |
| 4.x LTS | 4.6.0  | 2018-01-18 | False   | 2022-11-01 |
| 3.x     | 3.4.1  | 2013-08-19 | False   | 2019-07-24 |
| 2.x     | 2.3.2  | 2013-07-18 | False   | 2013-08-19 |

```json
[
{
"cycle": "5.x",
"release": "2021-05-05",
"eol": false,
"support": true,
"lts": true,
"latest": "5.0.1"
},
{
"cycle": "4.x",
"release": "2018-01-18",
"eol": "2022-11-01",
"latest": "4.6.0",
"lts": true,
"support": false
},
{
"cycle": "3.x",
"release": "2013-08-19",
"eol": "2019-07-24",
"latest": "3.4.1",
"support": false
},
{
"cycle": "2.x",
"release": "2013-07-18",
"eol": "2013-08-19",
"latest": "2.3.2",
"support": false
}
]
```


https://endoflife.date/api/bootstrap.json

There's also a `discontinued` date/Boolean field:

`eol iphone`


|            cycle            |  release   | discontinued |  eol  |
| --------------------------- | ---------- | ------------ | ----- |
| iPhone 5C                   | 2013-09-20 | 2015-09-09   | True  |
| iPhone 5S                   | 2013-09-20 | 2016-03-21   | True  |
| iPhone 6 / 6 Plus           | 2014-09-25 | 2016-09-07   | True  |
| iPhone 6S / 6S Plus         | 2015-09-25 | 2018-09-12   | False |
| iPhone SE (1st generation)  | 2016-03-31 | 2018-09-12   | False |
| iPhone 7 / 7 Plus           | 2016-09-16 | 2019-09-10   | False |
| iPhone 8 / 8 Plus           | 2017-09-22 | 2020-04-15   | False |
| iPhone X                    | 2017-09-12 | 2018-09-12   | False |
| iPhone XS / XS Max          | 2018-09-21 | 2019-09-10   | False |
| iPhone XR                   | 2018-10-26 | False        | False |
| iPhone 11                   | 2019-09-20 | False        | False |
| iPhone 11 Pro / 11 Pro Max  | 2019-09-20 | 2020-10-13   | False |
| iPhone SE (2nd generation)  | 2020-04-24 | False        | False |
| iPhone 12 / 12 Pro          | 2020-10-23 | False        | False |
| iPhone 12 Mini / 12 Pro Max | 2020-11-13 | False        | False |

```json
[
{
"cycle": "iPhone 5C",
"release": "2013-09-20",
"discontinued": "2015-09-09",
"eol": true
},
{
"cycle": "iPhone 5S",
"release": "2013-09-20",
"discontinued": "2016-03-21",
"eol": true
},
{
"cycle": "iPhone 6 / 6 Plus",
"release": "2014-09-25",
"discontinued": "2016-09-07",
"eol": true
},
{
"cycle": "iPhone 6S / 6S Plus",
"release": "2015-09-25",
"discontinued": "2018-09-12",
"eol": false
},
{
"cycle": "iPhone SE (1st generation)",
"release": "2016-03-31",
"discontinued": "2018-09-12",
"eol": false
},
{
"cycle": "iPhone 7 / 7 Plus",
"release": "2016-09-16",
"discontinued": "2019-09-10",
"eol": false
},
{
"cycle": "iPhone 8 / 8 Plus",
"release": "2017-09-22",
"discontinued": "2020-04-15",
"eol": false
},
{
"cycle": "iPhone X",
"release": "2017-09-12",
"discontinued": "2018-09-12",
"eol": false
},
{
"cycle": "iPhone XS / XS Max",
"release": "2018-09-21",
"discontinued": "2019-09-10",
"eol": false
},
{
"cycle": "iPhone XR",
"release": "2018-10-26",
"discontinued": false,
"eol": false
},
{
"cycle": "iPhone 11",
"release": "2019-09-20",
"discontinued": false,
"eol": false
},
{
"cycle": "iPhone 11 Pro / 11 Pro Max",
"release": "2019-09-20",
"discontinued": "2020-10-13",
"eol": false
},
{
"cycle": "iPhone SE (2nd generation)",
"release": "2020-04-24",
"discontinued": false,
"eol": false
},
{
"cycle": "iPhone 12 / 12 Pro",
"release": "2020-10-23",
"discontinued": false,
"eol": false
},
{
"cycle": "iPhone 12 Mini / 12 Pro Max",
"release": "2020-11-13",
"discontinued": false,
"eol": false
}
]
```

https://endoflife.date/api/iphone.json