### PR TITLE
List all tools with 'eol all'

### DIFF
--- a/src/norwegianblue/__init__.py
+++ b/src/norwegianblue/__init__.py
@@ -123,6 +123,10 @@ def norwegianblue(
         return json.dumps(res)
 
     data: list[dict] = list(res)
+
+    if tool == "all":
+        return "\n".join(data)
+
     data = _ltsify(data)
     if color != "no" and format != "html" and _can_do_colour():
         data = _colourify(data)

--- a/src/norwegianblue/cli.py
+++ b/src/norwegianblue/cli.py
@@ -11,7 +11,12 @@ def main():
     parser = argparse.ArgumentParser(
         description=__doc__, formatter_class=argparse.ArgumentDefaultsHelpFormatter
     )
-    parser.add_argument("tool", nargs="?", default="python", help="Tool to check")
+    parser.add_argument(
+        "tool",
+        nargs="?",
+        default="all",
+        help="Tool to check, or 'all' to list all available",
+    )
     parser.add_argument(
         "-f",
         "--format",

--- a/tests/test_norwegianblue.py
+++ b/tests/test_norwegianblue.py
@@ -80,6 +80,16 @@ SAMPLE_RESPONSE_JSON = """
 ]
 """
 
+SAMPLE_RESPONSE_ALL_JSON = """
+[
+    "alpine",
+    "amazon-linux",
+    "android",
+    "bootstrap",
+    "centos"
+]
+"""
+
 
 def stub__cache_filename(*args):
     return Path("/this/does/not/exist")
@@ -332,6 +342,20 @@ class TestNorwegianBlue:
         # Act
         output = norwegianblue._colourify(data)
         print(output)
+
+        # Assert
+        assert output == expected
+
+    @respx.mock
+    def test_all_tools(self):
+        # Arrange
+        mocked_url = "https://endoflife.date/api/all.json"
+        mocked_response = SAMPLE_RESPONSE_ALL_JSON
+        expected = """alpine\namazon-linux\nandroid\nbootstrap\ncentos"""
+
+        # Act
+        respx.get(mocked_url).respond(content=mocked_response)
+        output = norwegianblue.norwegianblue(tool="all")
 
         # Assert
         assert output == expected


### PR DESCRIPTION
Fixes #10.

And set `'all'` as the default:


```console
$ eol --help
usage: eol [-h] [-f {html,json,markdown,rst,tsv}] [-c {yes,no,auto}] [-v] [-V] [tool]

CLI to show end-of-life dates for tools and technologies.

positional arguments:
  tool                  Tool to check, or 'all' to list all available (default: all)

optional arguments:
  -h, --help            show this help message and exit
  -f {html,json,markdown,rst,tsv}, --format {html,json,markdown,rst,tsv}
                        The format of output (default: markdown)
  -c {yes,no,auto}, --color {yes,no,auto}
                        color terminal output (default: auto)
  -v, --verbose         Print debug messages to stderr (default: False)
  -V, --version         show program's version number and exit
```

```console
$ eol all
alpine
amazon-linux
android
bootstrap
centos
debian
django
dotnet
dotnetcore
dotnetfx
drupal
elasticsearch
elixir
fedora
filemaker
freebsd
go
godot
iphone
java
kindle
kubernetes
laravel
macos
magento
mariadb
mongodb
mssqlserver
mysql
nodejs
office
opensuse
perl
php
pixel
postgresql
powershell
python
qt
rabbitmq
rails
redis
rhel
ros
ruby
sles
spring-framework
surface
symfony
ubuntu
wagtail
windows
windowsembedded
windowsserver
```

```console
$ eol
alpine
amazon-linux
android
bootstrap
centos
debian
django
dotnet
dotnetcore
dotnetfx
drupal
elasticsearch
elixir
fedora
filemaker
freebsd
go
godot
iphone
java
kindle
kubernetes
laravel
macos
magento
mariadb
mongodb
mssqlserver
mysql
nodejs
office
opensuse
perl
php
pixel
postgresql
powershell
python
qt
rabbitmq
rails
redis
rhel
ros
ruby
sles
spring-framework
surface
symfony
ubuntu
wagtail
windows
windowsembedded
windowsserver
```

```console
$ eol python
| cycle | latest |  release   |    eol     |                                 link                                 |
| ----- | ------ | ---------- | ---------- | -------------------------------------------------------------------- |
| 3.9   | 3.9.6  | 2020-10-05 | 2025-10-05 | https://www.python.org/downloads/release/python-396/                 |
| 3.8   | 3.8.11 | 2019-10-14 | 2024-10-14 | https://www.python.org/downloads/release/python-3811/                |
| 3.7   | 3.7.11 | 2018-06-27 | 2023-06-27 | https://www.python.org/downloads/release/python-3711/                |
| 3.6   | 3.6.14 | 2016-12-23 | 2021-12-23 | https://www.python.org/downloads/release/python-3614/                |
| 3.5   | 3.5.10 | 2015-09-30 | 2020-09-13 | https://www.python.org/downloads/release/python-3510/                |
| 3.4   | 3.4.10 | 2014-03-16 | 2019-03-18 | https://www.python.org/downloads/release/python-3410/                |
| 3.3   | 3.3.7  | 2012-09-29 | 2017-09-29 | https://www.python.org/downloads/release/python-337/                 |
| 2.7   | 2.7.18 | 2010-07-03 | 2020-01-01 | https://github.com/python/cpython/blob/2.7/Misc/NEWS.d/2.7.18rc1.rst |
```