### PR TITLE
Bump minimum pytablewriter to fix trailing quotes

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 freezegun==1.1.0
 httpx==1.0.0b0
 platformdirs==2.3.0
-pytablewriter[html]==0.62.0
+pytablewriter[html]==0.63.0
 pytest==6.2.5
 pytest-cov==2.12.1
 python-slugify==5.0.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ packages = find:
 install_requires =
     httpx>=0.19
     platformdirs
-    pytablewriter[html]>=0.49
+    pytablewriter[html]>=0.63
     python-dateutil
     python-slugify
     termcolor

--- a/src/norwegianblue/__init__.py
+++ b/src/norwegianblue/__init__.py
@@ -99,8 +99,9 @@ def norwegianblue(
     """Call the API and return result"""
     url = BASE_URL + product.lower() + ".json"
     cache_file = _cache_filename(url)
-    _print_verbose(verbose, "API URL:", url)
-    _print_verbose(verbose, "Cache file:", cache_file)
+    _print_verbose(verbose, f"Human URL:\thttps://endoflife.date/{product.lower()}")
+    _print_verbose(verbose, f"API URL:\t{url}")
+    _print_verbose(verbose, f"Cache file:\t{cache_file}")
 
     res = {}
     if cache_file.is_file():
@@ -136,6 +137,7 @@ def norwegianblue(
         data = _colourify(data)
 
     output = _tabulate(data, format)
+    _print_verbose(verbose, "")
     return output
 
 

--- a/src/norwegianblue/cli.py
+++ b/src/norwegianblue/cli.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-CLI to show end-of-life dates for a number of products.
+CLI to show end-of-life dates for a number of products, from https://endoflife.date
 """
 import argparse
 import sys

--- a/tests/data/expected_output.py
+++ b/tests/data/expected_output.py
@@ -98,7 +98,7 @@ EXPECTED_MD_COLOUR = """
 
 
 EXPECTED_RST = """
-.. table:: 
+.. table::
 
     ===========  =========  ============  ============  ============  =====================================================
        cycle      latest      release       support         eol                               link                         


### PR DESCRIPTION
# Before

pytablewriter==0.62.0

See `Debian 11 "Bullseye`:

```console
$ eol debian
|          cycle           | latest |  release   |    eol     |                            link                             |
| ------------------------ | ------ | ---------- | ---------- | ----------------------------------------------------------- |
| Debian 11 "Bullseye      | 11.0   | 2021-08-14 | 2026-08-15 | https://www.debian.org/News/2021/20210814                   |
| Debian 10 "Buster        | 10.10  | 2019-07-06 | 2024-06-01 | https://www.debian.org/News/2021/20210619                   |
| Debian 9 "Stretch" (LTS) | 9.12   | 2017-06-17 | 2022-06-30 | https://lists.debian.org/debian-announce/2020/msg00001.html |
| Debian 9 "Stretch        | 9.12   | 2017-06-17 | 2020-01-01 | https://lists.debian.org/debian-announce/2020/msg00001.html |
| Debian 8 "Jessie" (LTS)  | 8.11   | 2015-04-26 | 2020-06-30 | https://www.debian.org/News/2015/20150426                   |
| Debian 8 "Jessie         | 8.11   | 2015-04-26 | 2018-06-17 | https://www.debian.org/News/2015/20150426                   |
| Debian 7 "Wheezy" (LTS)  | None   | 2013-05-04 | 2018-05-31 | https://www.debian.org/News/2013/20130504                   |
| Debian 7 "Wheezy         | None   | 2013-05-04 | 2016-04-25 | https://www.debian.org/News/2013/20130504                   |
| Debian 6 "Squeeze" (LTS) | None   | 2011-02-06 | 2016-02-29 | https://www.debian.org/News/2011/20110205a                  |
| Debian 6 "Squeeze        | None   | 2011-02-06 | 2014-05-31 | https://www.debian.org/News/2011/20110205a                  |
```

# After

pytablewriter==0.63.0

See `Debian 11 "Bullseye"`:

```console
$ eol debian
|          cycle           | latest |  release   |    eol     |                            link                             |
| ------------------------ | ------ | ---------- | ---------- | ----------------------------------------------------------- |
| Debian 11 "Bullseye"     | 11.0   | 2021-08-14 | 2026-08-15 | https://www.debian.org/News/2021/20210814                   |
| Debian 10 "Buster"       | 10.10  | 2019-07-06 | 2024-06-01 | https://www.debian.org/News/2021/20210619                   |
| Debian 9 "Stretch" (LTS) | 9.12   | 2017-06-17 | 2022-06-30 | https://lists.debian.org/debian-announce/2020/msg00001.html |
| Debian 9 "Stretch"       | 9.12   | 2017-06-17 | 2020-01-01 | https://lists.debian.org/debian-announce/2020/msg00001.html |
| Debian 8 "Jessie" (LTS)  | 8.11   | 2015-04-26 | 2020-06-30 | https://www.debian.org/News/2015/20150426                   |
| Debian 8 "Jessie"        | 8.11   | 2015-04-26 | 2018-06-17 | https://www.debian.org/News/2015/20150426                   |
| Debian 7 "Wheezy" (LTS)  | None   | 2013-05-04 | 2018-05-31 | https://www.debian.org/News/2013/20130504                   |
| Debian 7 "Wheezy"        | None   | 2013-05-04 | 2016-04-25 | https://www.debian.org/News/2013/20130504                   |
| Debian 6 "Squeeze" (LTS) | None   | 2011-02-06 | 2016-02-29 | https://www.debian.org/News/2011/20110205a                  |
| Debian 6 "Squeeze"       | None   | 2011-02-06 | 2014-05-31 | https://www.debian.org/News/2011/20110205a                  |
```

# Upstream fix

https://github.com/thombashi/pytablewriter/issues/49

# Also

Let's print the human `https://endoflife.date/product` URL with `--verbose`