### PR TITLE
Add support for Python 3.7-3.8 and PyPy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,10 +7,11 @@ on:
   release:
     types:
       - published
+  workflow_dispatch:
 
 jobs:
-  build:
-    if: github.repository == 'hugovk/norwegianblue'
+  deploy:
+    if: github.repository_owner == 'hugovk'
     runs-on: ubuntu-20.04
 
     steps:
@@ -29,18 +30,18 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.9
+          python-version: "3.10"
 
       - name: Install dependencies
         run: |
           python -m pip install -U pip
-          python -m pip install -U setuptools twine wheel
+          python -m pip install -U build twine wheel
 
       - name: Build package
         run: |
           python setup.py --version
-          python setup.py sdist --format=gztar bdist_wheel
-          twine check dist/*
+          python -m build
+          twine check --strict dist/*
 
       - name: Publish package to PyPI
         if: github.event.action == 'published'

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -1,12 +1,15 @@
 name: Sync labels
+
 on:
   push:
     branches:
       - main
     paths:
       - .github/labels.yml
+  workflow_dispatch:
+
 jobs:
-  build:
+  sync:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,6 @@
 name: Lint
 
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   lint:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,17 +1,17 @@
 name: Test
 
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 
 env:
   FORCE_COLOR: 1
 
 jobs:
-  build:
+  test:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10"]
+        python-version: ["pypy-3.7", "3.7", "3.8", "3.9", "3.10"]
         os: [ubuntu-latest, macos-latest, windows-latest]
         include:
           # Include new variables for Codecov

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,16 +3,13 @@ repos:
     rev: v2.29.0
     hooks:
       - id: pyupgrade
-        args: ["--py39-plus"]
+        args: ["--py37-plus"]
 
   - repo: https://github.com/psf/black
     rev: 21.9b0
     hooks:
       - id: black
-        args: ["--target-version", "py39"]
-        # override until resolved: https://github.com/psf/black/issues/402
-        files: \.pyi?$
-        types: []
+        args: ["--target-version", "py37"]
 
   - repo: https://github.com/PyCQA/isort
     rev: 5.9.3

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,7 +15,6 @@ classifiers =
     Operating System :: OS Independent
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
@@ -39,7 +38,7 @@ install_requires =
     python-dateutil
     python-slugify
     termcolor
-python_requires = >=3.6
+python_requires = >=3.7
 package_dir = =src
 setup_requires =
     setuptools_scm

--- a/src/norwegianblue/__init__.py
+++ b/src/norwegianblue/__init__.py
@@ -3,13 +3,14 @@
 Python interface to endoflife.date API
 https://endoflife.date/docs/api/
 """
+from __future__ import annotations
+
 import atexit
 import datetime as dt
 import json
 import os
 import sys
 from pathlib import Path
-from typing import Dict, List  # noqa: F401
 
 import httpx
 from dateutil.relativedelta import relativedelta

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     lint
-    py{36, 37, 38, 39, 310}
+    py{37, 38, 39, 310}
     pins
 
 [testenv]


### PR DESCRIPTION
https://github.com/hugovk/norwegianblue/pull/31 wasn't finished! Let's finish it here, and only for 3.7+ so we can use `from __future__ import annotations`. 3.6 is EOL in a couple of months anyway: https://endoflife.date/python

---

Unrelated, let's also use `python -m build` instead of `python setup.py sdist --format=gztar bdist_wheel` for building.

https://packaging.python.org/tutorials/packaging-projects/#generating-distribution-archives

Plus some other minor workflow updates.