### PR TITLE
Specify build backend to allow editable installs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,6 @@
+[build-system]
+requires = ["setuptools>=45", "wheel", "setuptools_scm[toml]>=6.2"]
+build-backend = "setuptools.build_meta"
+
 [tool.black]
 target_version = ["py37"]


### PR DESCRIPTION
Fixes editable installs.

With the old pip==21.2.4 we could do `python -m pip install -e .` for an editable install.

Now, with new pip==21.3 we need to specify the build backend. See:

> * Support editable installs for projects that have a pyproject.toml and use a build backend that supports PEP 660. (#8212)

https://pip.pypa.io/en/stable/news/#features

See also https://pip.pypa.io/en/stable/reference/build-system/pyproject-toml/