### PR TITLE
Add --clear-cache to delete all cache files before run

### DIFF
--- a/src/norwegianblue/__init__.py
+++ b/src/norwegianblue/__init__.py
@@ -71,6 +71,13 @@ def _save_cache(cache_file, data):
         pass
 
 
+def _clear_cache_now():
+    """Delete all cache files now"""
+    cache_files = CACHE_DIR.glob("**/*.json")
+    for cache_file in cache_files:
+        cache_file.unlink()
+
+
 def _clear_cache():
     """Delete old cache files, run as last task"""
     cache_files = CACHE_DIR.glob("**/*.json")
@@ -88,8 +95,11 @@ def norwegianblue(
     format: str = "markdown",
     color: str = "yes",
     verbose: bool = False,
+    clear_cache: bool = False,
 ) -> str:
     """Call the API and return result"""
+    if clear_cache:
+        _clear_cache_now()
     if product == "norwegianblue":
         from ._data import prefix, res
     else:

--- a/src/norwegianblue/cli.py
+++ b/src/norwegianblue/cli.py
@@ -33,6 +33,9 @@ def main():
         help="color terminal output",
     )
     parser.add_argument(
+        "--clear-cache", action="store_true", help="Clear cache before running"
+    )
+    parser.add_argument(
         "-v", "--verbose", action="store_true", help="Print debug messages to stderr"
     )
     parser.add_argument(
@@ -47,6 +50,7 @@ def main():
         format=args.format,
         color=args.color,
         verbose=args.verbose,
+        clear_cache=args.clear_cache,
     )
     if output == norwegianblue.ERROR_404_TEXT:
         sys.exit(output)

--- a/tests/test_norwegianblue_cache.py
+++ b/tests/test_norwegianblue_cache.py
@@ -68,6 +68,24 @@ class TestNorwegianBlueCache:
         assert new_data == data
 
     @freeze_time("2021-10-25")
+    def test__clear_cache_now(self):
+        # Arrange
+        # Create old cache file
+        cache_file_old = norwegianblue.CACHE_DIR / "2021-10-24-old-cache-file.json"
+        cache_file_new = norwegianblue.CACHE_DIR / "2021-10-25-new-cache-file.json"
+        norwegianblue._save_cache(cache_file_old, data={})
+        norwegianblue._save_cache(cache_file_new, data={})
+        assert cache_file_new.exists()
+        assert cache_file_old.exists()
+
+        # Act
+        norwegianblue._clear_cache_now()
+
+        # Assert
+        assert not cache_file_old.exists()
+        assert not cache_file_new.exists()
+
+    @freeze_time("2021-10-25")
     def test__clear_cache(self):
         # Arrange
         # Create old cache file


### PR DESCRIPTION
Useful in case the data has changed at the https://endoflife.date/ and we want to pull the newest data via the API.

Also, on exit, let's delete cache files older than today.

Previously it was deleting cache files older than this month. It was only ever reading in today's file, and the files aren't particularly big, but we might as well remove them sooner as there's no point loop through them every time in `_clear_cache()`.