### PR TITLE
Add __main__.py so runnable via 'python3 -m norwegianblue'

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -12,4 +12,5 @@ exclude_lines =
 
 [run]
 omit =
+    src/norwegianblue/__main__.py
     src/norwegianblue/cli.py

--- a/src/norwegianblue/__main__.py
+++ b/src/norwegianblue/__main__.py
@@ -1,0 +1,4 @@
+from norwegianblue import cli
+
+if __name__ == "__main__":
+    cli.main()


### PR DESCRIPTION
Is this still needed at the end of `src/norwegianblue/cli.py`?

```python
if __name__ == "__main__":
    main()
```