### PR TITLE
Speedup: only import httpx if needed

### DIFF
--- a/src/norwegianblue/__init__.py
+++ b/src/norwegianblue/__init__.py
@@ -12,7 +12,6 @@ import os
 import sys
 from pathlib import Path
 
-import httpx
 from dateutil.relativedelta import relativedelta
 from platformdirs import user_cache_dir
 from slugify import slugify
@@ -116,6 +115,8 @@ def norwegianblue(
 
     if res == {}:
         # No cache, or couldn't load cache
+        import httpx
+
         r = httpx.get(url, headers={"User-Agent": USER_AGENT})
 
         _print_verbose(verbose, "HTTP status code:", r.status_code)


### PR DESCRIPTION
Here's how to use `python -X importtime` and tuna to identify bottlenecks: https://medium.com/alan/how-we-improved-our-python-backend-start-up-time-2c33cd4873c8

Running:

```sh
python -X importtime -c "import norwegianblue; norwegianblue.norwegianblue('python')" 2> import.log
tuna import.log
```

Shows importing httpx can take ~250 ms, which is unnecessary when loading a cached file (i.e. we've already run the command today).

Let's show tuna output from earlier speedups.

# Baseline: 697f838ba0d57ce63a9d440b2f816c1e7897b21a

Slow imports: httpx, pkg_resources, pytablewriter.

704 ms.

![image](https://user-images.githubusercontent.com/1324225/139542194-c8d971e8-e657-4855-96b5-c54aea258192.png)

# Speedup: Use faster PrettyTable for Markdown (https://github.com/hugovk/norwegianblue/pull/29)

Use PrettyTable for default Markdown output, it's much lighter to import.

704 -> 599 ms.

![image](https://user-images.githubusercontent.com/1324225/139542247-0a5d82aa-a750-4ce6-becd-cdda2b993f16.png)

# Speedup: Write version to file to avoid overhead of pkg_resources.get_distribution (https://github.com/hugovk/norwegianblue/pull/30)

599 -> 353 ms.

![image](https://user-images.githubusercontent.com/1324225/139542271-964fe889-663a-42e2-8458-5168047d2714.png)

# Speedup: only import httpx if needed (this PR) 

599 -> 134 ms.

![image](https://user-images.githubusercontent.com/1324225/139542285-c297f02a-8c52-43b3-a85f-ad6b07c3dd07.png)
