### PR TITLE
Only align necessary columns and not whole table

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 # Only for testing pinned versions on the CI
 freezegun==1.1.0
-httpx==1.0.0b0
+httpx==0.20.0
 platformdirs==2.4.0
-prettytable==2.2.1
+prettytable==2.4.0
 pytablewriter[html]==0.64.1
 pytest==6.2.5
 pytest-cov==3.0.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ packages = find:
 install_requires =
     httpx>=0.19
     platformdirs
-    prettytable
+    prettytable>=2.4.0
     pytablewriter[html]>=0.63
     python-dateutil
     python-slugify

--- a/src/norwegianblue/__init__.py
+++ b/src/norwegianblue/__init__.py
@@ -244,7 +244,7 @@ def _prettytable(headers: list[str], data: list[dict]) -> str:
         col_data = [row[header] if header in row else "" for row in data]
         x.add_column(header, col_data)
         if header in ("cycle", "latest", "link"):
-            x.align = "l"
+            x.align[header] = "l"
 
     return x.get_string()
 
@@ -263,9 +263,11 @@ def _pytablewriter(headers: list[str], data: list[dict], format: str) -> str:
         "rst": RstSimpleTableWriter,
         "tsv": TsvTableWriter,
     }
+
     writer = format_writers[format]()
     if format != "html":
         writer.margin = 1
+
     writer.headers = headers
     writer.value_matrix = data
 

--- a/tests/data/expected_output.py
+++ b/tests/data/expected_output.py
@@ -72,8 +72,8 @@ EXPECTED_HTML = """
 """
 
 EXPECTED_MD = """
-| cycle     | latest  | release    | support    | eol        | link                                                |
-|-----------|---------|------------|------------|------------|-----------------------------------------------------|
+| cycle     | latest  |  release   |  support   |    eol     | link                                                |
+|:----------|:--------|:----------:|:----------:|:----------:|:----------------------------------------------------|
 | 21.04 LTS | 21.04   | 2021-04-22 | 2022-01-01 | 2022-01-01 | https://wiki.ubuntu.com/HirsuteHippo/ReleaseNotes/  |
 | 20.10 LTS | 20.10   | 2020-10-22 | 2021-07-07 | 2021-07-07 | https://wiki.ubuntu.com/GroovyGorilla/ReleaseNotes/ |
 | 20.04 LTS | 20.04.2 | 2020-04-23 | 2022-10-01 | 2025-04-02 |                                                     |
@@ -85,8 +85,8 @@ EXPECTED_MD = """
 
 
 EXPECTED_MD_COLOUR = """
-| cycle     | latest  | release    | support    | eol        | link                                                |
-|-----------|---------|------------|------------|------------|-----------------------------------------------------|
+| cycle     | latest  |  release   |  support   |    eol     | link                                                |
+|:----------|:--------|:----------:|:----------:|:----------:|:----------------------------------------------------|
 | 21.04 LTS | 21.04   | 2021-04-22 | \x1b[33m2022-01-01\x1b[0m | \x1b[33m2022-01-01\x1b[0m | https://wiki.ubuntu.com/HirsuteHippo/ReleaseNotes/  |
 | 20.10 LTS | 20.10   | 2020-10-22 | \x1b[31m2021-07-07\x1b[0m | \x1b[31m2021-07-07\x1b[0m | https://wiki.ubuntu.com/GroovyGorilla/ReleaseNotes/ |
 | 20.04 LTS | 20.04.2 | 2020-04-23 | \x1b[32m2022-10-01\x1b[0m | \x1b[32m2025-04-02\x1b[0m |                                                     |


### PR DESCRIPTION
And require PrettyTable 2.4.0 because it now adds colons in the column to align the rendered output.

And update tests to match.