### PR TITLE
Fix labelling LTS releases

### DIFF
--- a/src/norwegianblue/__init__.py
+++ b/src/norwegianblue/__init__.py
@@ -156,7 +156,8 @@ def _ltsify(data: list[dict]) -> list[dict]:
     """If a cycle is LTS, append LTS to the cycle version and remove the LTS column"""
     for cycle in data:
         if "lts" in cycle:
-            cycle["cycle"] = f"{cycle['cycle']} LTS"
+            if cycle["lts"]:
+                cycle["cycle"] = f"{cycle['cycle']} LTS"
             cycle.pop("lts")
     return data
 

--- a/tests/data/expected_output.py
+++ b/tests/data/expected_output.py
@@ -12,7 +12,7 @@ EXPECTED_HTML = """
     </thead>
     <tbody>
         <tr>
-            <td align="left">21.04 LTS</td>
+            <td align="left">21.04</td>
             <td align="left">21.04</td>
             <td align="left">2021-04-22</td>
             <td align="left">2022-01-01</td>
@@ -20,7 +20,7 @@ EXPECTED_HTML = """
             <td align="left">https://wiki.ubuntu.com/HirsuteHippo/ReleaseNotes/</td>
         </tr>
         <tr>
-            <td align="left">20.10 LTS</td>
+            <td align="left">20.10</td>
             <td align="left">20.10</td>
             <td align="left">2020-10-22</td>
             <td align="left">2021-07-07</td>
@@ -74,8 +74,8 @@ EXPECTED_HTML = """
 EXPECTED_MD = """
 | cycle     | latest  |  release   |  support   |    eol     | link                                                |
 |:----------|:--------|:----------:|:----------:|:----------:|:----------------------------------------------------|
-| 21.04 LTS | 21.04   | 2021-04-22 | 2022-01-01 | 2022-01-01 | https://wiki.ubuntu.com/HirsuteHippo/ReleaseNotes/  |
-| 20.10 LTS | 20.10   | 2020-10-22 | 2021-07-07 | 2021-07-07 | https://wiki.ubuntu.com/GroovyGorilla/ReleaseNotes/ |
+| 21.04     | 21.04   | 2021-04-22 | 2022-01-01 | 2022-01-01 | https://wiki.ubuntu.com/HirsuteHippo/ReleaseNotes/  |
+| 20.10     | 20.10   | 2020-10-22 | 2021-07-07 | 2021-07-07 | https://wiki.ubuntu.com/GroovyGorilla/ReleaseNotes/ |
 | 20.04 LTS | 20.04.2 | 2020-04-23 | 2022-10-01 | 2025-04-02 |                                                     |
 | 19.10     | 19.10   | 2019-10-17 | 2020-07-06 | 2020-07-06 |                                                     |
 | 18.04 LTS | 18.04.5 | 2018-04-26 | 2020-09-30 | 2023-04-02 |                                                     |
@@ -87,8 +87,8 @@ EXPECTED_MD = """
 EXPECTED_MD_COLOUR = """
 | cycle     | latest  |  release   |  support   |    eol     | link                                                |
 |:----------|:--------|:----------:|:----------:|:----------:|:----------------------------------------------------|
-| 21.04 LTS | 21.04   | 2021-04-22 | \x1b[33m2022-01-01\x1b[0m | \x1b[33m2022-01-01\x1b[0m | https://wiki.ubuntu.com/HirsuteHippo/ReleaseNotes/  |
-| 20.10 LTS | 20.10   | 2020-10-22 | \x1b[31m2021-07-07\x1b[0m | \x1b[31m2021-07-07\x1b[0m | https://wiki.ubuntu.com/GroovyGorilla/ReleaseNotes/ |
+| 21.04     | 21.04   | 2021-04-22 | \x1b[33m2022-01-01\x1b[0m | \x1b[33m2022-01-01\x1b[0m | https://wiki.ubuntu.com/HirsuteHippo/ReleaseNotes/  |
+| 20.10     | 20.10   | 2020-10-22 | \x1b[31m2021-07-07\x1b[0m | \x1b[31m2021-07-07\x1b[0m | https://wiki.ubuntu.com/GroovyGorilla/ReleaseNotes/ |
 | 20.04 LTS | 20.04.2 | 2020-04-23 | \x1b[32m2022-10-01\x1b[0m | \x1b[32m2025-04-02\x1b[0m |                                                     |
 | 19.10     | 19.10   | 2019-10-17 | \x1b[31m2020-07-06\x1b[0m | \x1b[31m2020-07-06\x1b[0m |                                                     |
 | 18.04 LTS | 18.04.5 | 2018-04-26 | \x1b[31m2020-09-30\x1b[0m | \x1b[32m2023-04-02\x1b[0m |                                                     |
@@ -103,8 +103,8 @@ EXPECTED_RST = """
     ===========  =========  ============  ============  ============  =====================================================
        cycle      latest      release       support         eol                               link                         
     ===========  =========  ============  ============  ============  =====================================================
-     21.04 LTS    21.04      2021-04-22    2022-01-01    2022-01-01    https://wiki.ubuntu.com/HirsuteHippo/ReleaseNotes/  
-     20.10 LTS    20.10      2020-10-22    2021-07-07    2021-07-07    https://wiki.ubuntu.com/GroovyGorilla/ReleaseNotes/ 
+     21.04        21.04      2021-04-22    2022-01-01    2022-01-01    https://wiki.ubuntu.com/HirsuteHippo/ReleaseNotes/  
+     20.10        20.10      2020-10-22    2021-07-07    2021-07-07    https://wiki.ubuntu.com/GroovyGorilla/ReleaseNotes/ 
      20.04 LTS    20.04.2    2020-04-23    2022-10-01    2025-04-02                                                        
      19.10        19.10      2019-10-17    2020-07-06    2020-07-06                                                        
      18.04 LTS    18.04.5    2018-04-26    2020-09-30    2023-04-02                                                        
@@ -115,8 +115,8 @@ EXPECTED_RST = """
 
 EXPECTED_TSV = """
 "cycle"	"latest"	"release"	"support"	"eol"	"link"
-"21.04 LTS"	"21.04"	"2021-04-22"	"2022-01-01"	"2022-01-01"	"https://wiki.ubuntu.com/HirsuteHippo/ReleaseNotes/"
-"20.10 LTS"	"20.10"	"2020-10-22"	"2021-07-07"	"2021-07-07"	"https://wiki.ubuntu.com/GroovyGorilla/ReleaseNotes/"
+"21.04"	"21.04"	"2021-04-22"	"2022-01-01"	"2022-01-01"	"https://wiki.ubuntu.com/HirsuteHippo/ReleaseNotes/"
+"20.10"	"20.10"	"2020-10-22"	"2021-07-07"	"2021-07-07"	"https://wiki.ubuntu.com/GroovyGorilla/ReleaseNotes/"
 "20.04 LTS"	"20.04.2"	"2020-04-23"	"2022-10-01"	"2025-04-02"	
 "19.10"	"19.10"	"2019-10-17"	"2020-07-06"	"2020-07-06"	
 "18.04 LTS"	"18.04.5"	"2018-04-26"	"2020-09-30"	"2023-04-02"	

--- a/tests/test_norwegianblue.py
+++ b/tests/test_norwegianblue.py
@@ -425,3 +425,24 @@ class TestNorwegianBlue:
         # Assert
         print(output)
         assert "Norwegian Blue" in output
+
+    def test__ltsify(self):
+        # Arrange
+        data = [
+            {"cycle": "5.3", "eol": "2022-01-01", "lts": False},
+            {"cycle": "4.4", "eol": "2023-11-21", "lts": True},
+            {"cycle": "4.3", "eol": "2020-07-01", "lts": False},
+            {"cycle": "3.4", "eol": "2021-11-01", "lts": True},
+        ]
+        expected = [
+            {"cycle": "5.3", "eol": "2022-01-01"},
+            {"cycle": "4.4 LTS", "eol": "2023-11-21"},
+            {"cycle": "4.3", "eol": "2020-07-01"},
+            {"cycle": "3.4 LTS", "eol": "2021-11-01"},
+        ]
+
+        # Act
+        output = norwegianblue._ltsify(data)
+
+        # Assert
+        assert output == expected


### PR DESCRIPTION
# Before

| cycle   | latest |  release   |  support   |    eol     |
|:--------|:-------|:----------:|:----------:|:----------:|
| 5.3 LTS | 5.3.9  | 2021-05-31 | 2022-01-01 | 2022-01-01 |
| 5.2 LTS | 5.2.14 | 2020-11-30 | 2021-07-21 | 2021-07-21 |
| 5.1 LTS | 5.1.11 | 2020-05-31 | 2021-01-21 | 2021-01-21 |
| 5.0 LTS | 5.0.11 | 2019-11-21 | 2020-07-21 | 2020-07-21 |
| 4.4 LTS | 4.4.32 | 2019-11-21 | 2022-11-21 | 2023-11-21 |
| 4.3 LTS | 4.3.11 | 2019-05-01 | 2020-01-01 | 2020-07-01 |
| 4.2 LTS | 4.2.12 | 2018-11-01 | 2019-07-01 | 2020-01-01 |
| 4.1 LTS | 4.1.13 | 2018-05-01 | 2019-01-01 | 2019-07-01 |
| 4.0 LTS | 4.0.15 | 2017-11-01 | 2018-07-01 | 2019-01-01 |
| 3.4 LTS | 3.4.49 | 2017-11-01 | 2020-11-01 | 2021-11-01 |
| 3.3 LTS | 3.3.18 | 2017-05-01 | 2018-01-01 | 2018-07-01 |
| 3.2 LTS | 3.2.14 | 2016-11-01 | 2017-07-01 | 2018-01-01 |
| 3.1 LTS | 3.1.10 | 2016-05-01 | 2017-01-01 | 2017-07-01 |
| 3.0 LTS | 3.0.9  | 2015-11-01 | 2016-07-01 | 2017-01-01 |
| 2.8 LTS | 2.8.52 | 2015-11-01 | 2018-11-01 | 2019-11-01 |
| 2.7 LTS | 2.7.52 | 2015-05-01 | 2018-05-01 | 2019-05-01 |
| 2.3 LTS | 2.3.42 | 2013-05-01 | 2016-05-01 | 2017-05-01 |

# After

| cycle   | latest |  release   |  support   |    eol     |
|:--------|:-------|:----------:|:----------:|:----------:|
| 5.3     | 5.3.9  | 2021-05-31 | 2022-01-01 | 2022-01-01 |
| 5.2     | 5.2.14 | 2020-11-30 | 2021-07-21 | 2021-07-21 |
| 5.1     | 5.1.11 | 2020-05-31 | 2021-01-21 | 2021-01-21 |
| 5.0     | 5.0.11 | 2019-11-21 | 2020-07-21 | 2020-07-21 |
| 4.4 LTS | 4.4.32 | 2019-11-21 | 2022-11-21 | 2023-11-21 |
| 4.3     | 4.3.11 | 2019-05-01 | 2020-01-01 | 2020-07-01 |
| 4.2     | 4.2.12 | 2018-11-01 | 2019-07-01 | 2020-01-01 |
| 4.1     | 4.1.13 | 2018-05-01 | 2019-01-01 | 2019-07-01 |
| 4.0     | 4.0.15 | 2017-11-01 | 2018-07-01 | 2019-01-01 |
| 3.4 LTS | 3.4.49 | 2017-11-01 | 2020-11-01 | 2021-11-01 |
| 3.3     | 3.3.18 | 2017-05-01 | 2018-01-01 | 2018-07-01 |
| 3.2     | 3.2.14 | 2016-11-01 | 2017-07-01 | 2018-01-01 |
| 3.1     | 3.1.10 | 2016-05-01 | 2017-01-01 | 2017-07-01 |
| 3.0     | 3.0.9  | 2015-11-01 | 2016-07-01 | 2017-01-01 |
| 2.8 LTS | 2.8.52 | 2015-11-01 | 2018-11-01 | 2019-11-01 |
| 2.7 LTS | 2.7.52 | 2015-05-01 | 2018-05-01 | 2019-05-01 |
| 2.3 LTS | 2.3.42 | 2013-05-01 | 2016-05-01 | 2017-05-01 |