### PR TITLE
Add examples to --help

### DIFF
--- a/src/norwegianblue/cli.py
+++ b/src/norwegianblue/cli.py
@@ -1,6 +1,14 @@
 #!/usr/bin/env python3
 """
 CLI to show end-of-life dates for a number of products, from https://endoflife.date
+
+For example:
+
+* `eol python` to see Python EOLs
+* `eol ubuntu` to see Ubuntu EOLs
+* `eol all` to list all available products
+
+Something missing? Please contribute! https://endoflife.date/contribute
 """
 import argparse
 import sys
@@ -8,10 +16,15 @@ import sys
 import norwegianblue
 
 
+class Formatter(
+    argparse.ArgumentDefaultsHelpFormatter,
+    argparse.RawDescriptionHelpFormatter,
+):
+    pass
+
+
 def main():
-    parser = argparse.ArgumentParser(
-        description=__doc__, formatter_class=argparse.ArgumentDefaultsHelpFormatter
-    )
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=Formatter)
     parser.add_argument(
         "product",
         nargs="?",


### PR DESCRIPTION
# Before

```console
$ eol --help
usage: eol [-h] [-f {html,json,markdown,rst,tsv}] [-c {yes,no,auto}]
           [--clear-cache] [-v] [-V]
           [product]

CLI to show end-of-life dates for a number of products, from
https://endoflife.date

positional arguments:
  product               Product to check, or 'all' to list all available
                        (default: all)

options:
  -h, --help            show this help message and exit
  -f {html,json,markdown,rst,tsv}, --format {html,json,markdown,rst,tsv}
                        The format of output (default: markdown)
  -c {yes,no,auto}, --color {yes,no,auto}
                        color terminal output (default: auto)
  --clear-cache         Clear cache before running (default: False)
  -v, --verbose         Print debug messages to stderr (default: False)
  -V, --version         show program's version number and exit
```

# After

```console
$ eol --help
usage: eol [-h] [-f {html,json,markdown,rst,tsv}] [-c {yes,no,auto}]
           [--clear-cache] [-v] [-V]
           [product]

CLI to show end-of-life dates for a number of products, from https://endoflife.date

For example:

* `eol python` to see Python EOLs
* `eol ubuntu` to see Ubuntu EOLs
* `eol all` to list all available products

Something missing? Please contribute! https://endoflife.date/contribute

positional arguments:
  product               Product to check, or 'all' to list all available
                        (default: all)

options:
  -h, --help            show this help message and exit
  -f {html,json,markdown,rst,tsv}, --format {html,json,markdown,rst,tsv}
                        The format of output (default: markdown)
  -c {yes,no,auto}, --color {yes,no,auto}
                        color terminal output (default: auto)
  --clear-cache         Clear cache before running (default: False)
  -v, --verbose         Print debug messages to stderr (default: False)
  -V, --version         show program's version number and exit
```