### PR TITLE
httpx: Enable following redirects

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,21 +3,21 @@ repos:
     rev: v2.29.0
     hooks:
       - id: pyupgrade
-        args: ["--py37-plus"]
+        args: [--py37-plus]
 
   - repo: https://github.com/psf/black
-    rev: 21.9b0
+    rev: 21.10b0
     hooks:
       - id: black
-        args: ["--target-version", "py37"]
+        args: [--target-version=py37]
 
   - repo: https://github.com/PyCQA/isort
-    rev: 5.9.3
+    rev: 5.10.0
     hooks:
       - id: isort
 
   - repo: https://github.com/PyCQA/flake8
-    rev: 3.9.2
+    rev: 4.0.1
     hooks:
       - id: flake8
         additional_dependencies: [flake8-2020, flake8-implicit-str-concat]
@@ -36,7 +36,7 @@ repos:
       - id: requirements-txt-fixer
 
   - repo: https://github.com/asottile/setup-cfg-fmt
-    rev: v1.18.0
+    rev: v1.19.0
     hooks:
       - id: setup-cfg-fmt
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,7 +41,7 @@ install_requires =
 python_requires = >=3.7
 package_dir = =src
 setup_requires =
-    setuptools_scm
+    setuptools-scm
 zip_safe = True
 
 [options.packages.find]

--- a/src/norwegianblue/__init__.py
+++ b/src/norwegianblue/__init__.py
@@ -117,7 +117,7 @@ def norwegianblue(
         # No cache, or couldn't load cache
         import httpx
 
-        r = httpx.get(url, headers={"User-Agent": USER_AGENT})
+        r = httpx.get(url, follow_redirects=True, headers={"User-Agent": USER_AGENT})
 
         _print_verbose(verbose, "HTTP status code:", r.status_code)
         if r.status_code == 404:


### PR DESCRIPTION
# Before

```console
$ eol node --clear-cache
Traceback (most recent call last):
  File "/Library/Frameworks/Python.framework/Versions/3.10/bin/eol", line 33, in <module>
    sys.exit(load_entry_point('norwegianblue', 'console_scripts', 'eol')())
  File "/Users/hugo/github/norwegianblue/src/norwegianblue/cli.py", line 61, in main
    output = norwegianblue.norwegianblue(
  File "/Users/hugo/github/norwegianblue/src/norwegianblue/__init__.py", line 128, in norwegianblue
    r.raise_for_status()
  File "/Library/Frameworks/Python.framework/Versions/3.10/lib/python3.10/site-packages/httpx/_models.py", line 1507, in raise_for_status
    raise HTTPStatusError(message, request=request, response=self)
httpx.HTTPStatusError: Redirect response '301 Moved Permanently' for url 'https://endoflife.date/api/node.json'
Redirect location: '/api/nodejs.json'
For more information check: https://httpstatuses.com/301
```

# After

```console
$ eol node --clear-cache
| cycle  | latest  |  release   |  support   |    eol     |
|:-------|:--------|:----------:|:----------:|:----------:|
| 17     | 17.0.1  | 2021-10-19 | 2022-04-01 | 2022-06-01 |
| 16 LTS | 16.13.0 | 2021-04-20 | 2022-10-18 | 2024-04-30 |
| 15     | 15.14.0 | 2020-10-20 | 2021-04-01 | 2021-06-01 |
| 14 LTS | 14.18.1 | 2020-04-21 | 2021-10-19 | 2023-04-30 |
| 12 LTS | 12.22.7 | 2019-04-23 | 2020-10-20 | 2022-04-30 |
| 10 LTS | 10.24.1 | 2018-04-24 | 2020-05-19 | 2021-04-30 |
```
