### PR TITLE
Use cog to update README usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![GitHub](https://img.shields.io/github/license/hugovk/norwegianblue.svg)](LICENSE.txt)
 [![Code style: Black](https://img.shields.io/badge/code%20style-Black-000000.svg)](https://github.com/psf/black)
 
-Python 3.7+ interface to [endoflife.date](https://endoflife.date/docs/api/) to show
+Python interface to [endoflife.date](https://endoflife.date/docs/api/) to show
 end-of-life dates for a number of products.
 
 ## Installation
@@ -33,88 +33,137 @@ Run `norwegianblue` or `eol`, they do the same thing.
 
 Top-level help:
 
+<!-- [[[cog
+from scripts.run_command import run
+run("eol --help")
+]]] -->
+
 ```console
 $ eol --help
-usage: eol [-h] [-f {html,json,markdown,rst,tsv}] [-c {yes,no,auto}] [-v] [-V]
+usage: eol [-h] [-f {html,json,markdown,rst,tsv}] [-c {yes,no,auto}]
+           [--clear-cache] [-v] [-V]
            [product]
 
-CLI to show end-of-life dates for a number of products.
+CLI to show end-of-life dates for a number of products, from https://endoflife.date
+
+For example:
+
+* `eol python` to see Python EOLs
+* `eol ubuntu` to see Ubuntu EOLs
+* `eol all` to list all available products
+
+Something missing? Please contribute! https://endoflife.date/contribute
 
 positional arguments:
   product               Product to check, or 'all' to list all available
                         (default: all)
 
-optional arguments:
+options:
   -h, --help            show this help message and exit
   -f {html,json,markdown,rst,tsv}, --format {html,json,markdown,rst,tsv}
                         The format of output (default: markdown)
   -c {yes,no,auto}, --color {yes,no,auto}
                         color terminal output (default: auto)
+  --clear-cache         Clear cache before running (default: False)
   -v, --verbose         Print debug messages to stderr (default: False)
   -V, --version         show program's version number and exit
 ```
+
+<!-- [[[end]]] -->
 
 List all available products with end-of-life dates:
 
 ```console
 $ # eol all
 $ # or:
+```
+
+<!-- [[[cog
+from scripts.run_command import run
+run("eol", line_limit=5)
+]]] -->
+
+```console
 $ eol
 alpine
+amazon-eks
 amazon-linux
 android
-bootstrap
-centos
+angular
 ...
 ```
 
+<!-- [[[end]]] -->
+
 Show end-of-life dates:
+
+<!-- [[[cog
+from scripts.run_command import run
+run("norwegianblue python")
+]]] -->
 
 ```console
 $ norwegianblue python
-| cycle | latest |  release   |    eol     |                                 link                                 |
-| ----- | ------ | ---------- | ---------- | -------------------------------------------------------------------- |
-| 3.9   | 3.9.6  | 2020-10-05 | 2025-10-05 | https://www.python.org/downloads/release/python-396/                 |
-| 3.8   | 3.8.11 | 2019-10-14 | 2024-10-14 | https://www.python.org/downloads/release/python-3811/                |
-| 3.7   | 3.7.11 | 2018-06-27 | 2023-06-27 | https://www.python.org/downloads/release/python-3711/                |
-| 3.6   | 3.6.14 | 2016-12-23 | 2021-12-23 | https://www.python.org/downloads/release/python-3614/                |
-| 3.5   | 3.5.10 | 2015-09-30 | 2020-09-13 | https://www.python.org/downloads/release/python-3510/                |
-| 3.4   | 3.4.10 | 2014-03-16 | 2019-03-18 | https://www.python.org/downloads/release/python-3410/                |
-| 3.3   | 3.3.7  | 2012-09-29 | 2017-09-29 | https://www.python.org/downloads/release/python-337/                 |
-| 2.7   | 2.7.18 | 2010-07-03 | 2020-01-01 | https://github.com/python/cpython/blob/2.7/Misc/NEWS.d/2.7.18rc1.rst |
+| cycle | latest |  release   |    eol     |
+|:------|:-------|:----------:|:----------:|
+| 3.10  | 3.10.0 | 2021-10-04 | 2026-10-04 |
+| 3.9   | 3.9.9  | 2020-10-05 | 2025-10-05 |
+| 3.8   | 3.8.12 | 2019-10-14 | 2024-10-14 |
+| 3.7   | 3.7.12 | 2018-06-27 | 2023-06-27 |
+| 3.6   | 3.6.15 | 2016-12-23 | 2021-12-23 |
+| 3.5   | 3.5.10 | 2015-09-30 | 2020-09-13 |
+| 3.4   | 3.4.10 | 2014-03-16 | 2019-03-18 |
+| 3.3   | 3.3.7  | 2012-09-29 | 2017-09-29 |
+| 2.7   | 2.7.18 | 2010-07-03 | 2020-01-01 |
 ```
+
+<!-- [[[end]]] -->
 
 The table is Markdown, ready for pasting in GitHub issues and PRs:
 
-| cycle | latest | release    | eol        | link                                                                 |
-| ----- | ------ | ---------- | ---------- | -------------------------------------------------------------------- |
-| 3.9   | 3.9.6  | 2020-10-05 | 2025-10-05 | https://www.python.org/downloads/release/python-396/                 |
-| 3.8   | 3.8.11 | 2019-10-14 | 2024-10-14 | https://www.python.org/downloads/release/python-3811/                |
-| 3.7   | 3.7.11 | 2018-06-27 | 2023-06-27 | https://www.python.org/downloads/release/python-3711/                |
-| 3.6   | 3.6.14 | 2016-12-23 | 2021-12-23 | https://www.python.org/downloads/release/python-3614/                |
-| 3.5   | 3.5.10 | 2015-09-30 | 2020-09-13 | https://www.python.org/downloads/release/python-3510/                |
-| 3.4   | 3.4.10 | 2014-03-16 | 2019-03-18 | https://www.python.org/downloads/release/python-3410/                |
-| 3.3   | 3.3.7  | 2012-09-29 | 2017-09-29 | https://www.python.org/downloads/release/python-337/                 |
-| 2.7   | 2.7.18 | 2010-07-03 | 2020-01-01 | https://github.com/python/cpython/blob/2.7/Misc/NEWS.d/2.7.18rc1.rst |
+<!-- [[[cog
+from scripts.run_command import run
+run("norwegianblue python", with_console=False)
+]]] -->
+
+| cycle | latest |  release   |    eol     |
+| :---- | :----- | :--------: | :--------: |
+| 3.10  | 3.10.0 | 2021-10-04 | 2026-10-04 |
+| 3.9   | 3.9.9  | 2020-10-05 | 2025-10-05 |
+| 3.8   | 3.8.12 | 2019-10-14 | 2024-10-14 |
+| 3.7   | 3.7.12 | 2018-06-27 | 2023-06-27 |
+| 3.6   | 3.6.15 | 2016-12-23 | 2021-12-23 |
+| 3.5   | 3.5.10 | 2015-09-30 | 2020-09-13 |
+| 3.4   | 3.4.10 | 2014-03-16 | 2019-03-18 |
+| 3.3   | 3.3.7  | 2012-09-29 | 2017-09-29 |
+| 2.7   | 2.7.18 | 2010-07-03 | 2020-01-01 |
+
+<!-- [[[end]]] -->
 
 With options:
 
+<!-- [[[cog
+from scripts.run_command import run
+run("eol nodejs --format rst")
+]]] -->
+
 ```console
-$ eol ubuntu --format rst
+$ eol nodejs --format rst
 .. table::
 
-    ===========  =========  ============  ============  ============  =====================================================
-       cycle      latest      release       support         eol                               link
-    ===========  =========  ============  ============  ============  =====================================================
-     21.04 LTS    21.04      2021-04-22    2022-01-01    2022-01-01    https://wiki.ubuntu.com/HirsuteHippo/ReleaseNotes/
-     20.10 LTS    20.10      2020-10-22    2021-07-07    2021-07-07    https://wiki.ubuntu.com/GroovyGorilla/ReleaseNotes/
-     20.04 LTS    20.04.2    2020-04-23    2022-10-01    2025-04-02
-     19.10        19.10      2019-10-17    2020-07-06    2020-07-06
-     18.04 LTS    18.04.5    2018-04-26    2020-09-30    2023-04-02
-     16.04 LTS    16.04.7    2016-04-21    2018-10-01    2021-04-02
-     14.04 LTS    14.04.6    2014-04-17    2016-09-30    2019-04-02
-    ===========  =========  ============  ============  ============  =====================================================
+    ========  =========  ============  ============  ============
+     cycle     latest      release       support         eol
+    ========  =========  ============  ============  ============
+     17        17.1.0     2021-10-19    2022-04-01    2022-06-01
+     16 LTS    16.13.0    2021-04-20    2022-10-18    2024-04-30
+     15        15.14.0    2020-10-20    2021-04-01    2021-06-01
+     14 LTS    14.18.1    2020-04-21    2021-10-19    2023-04-30
+     12 LTS    12.22.7    2019-04-23    2020-10-20    2022-04-30
+     10 LTS    10.24.1    2018-04-24    2020-05-19    2021-04-30
+    ========  =========  ============  ============  ============
 ```
+
+<!-- [[[end]]] -->
 
 ## Example programmatic use
 

--- a/scripts/run_command.py
+++ b/scripts/run_command.py
@@ -1,0 +1,18 @@
+import subprocess
+
+
+def run(command: str, with_console: bool = True, line_limit: int = None) -> None:
+    output = subprocess.run(command.split(), capture_output=True, text=True)
+    print()
+    if with_console:
+        print("```console")
+        print(f"$ {command}")
+
+    output = output.stdout.strip()
+    if line_limit:
+        output = "".join(output.splitlines(keepends=True)[:line_limit]) + "..."
+    print(output)
+
+    if with_console:
+        print("```")
+    print()

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,6 @@
 [tox]
 envlist =
+    cog
     lint
     py{37, 38, 39, 310}
     pins
@@ -17,13 +18,18 @@ commands =
     eol --version
     eol --help
 
-[testenv:pins]
-extras = None
-commands_pre =
-    {envpython} -m pip install -r requirements.txt
+[testenv:cog]
+deps = cogapp
+commands = cog -Pr README.md
+skip_install = true
 
 [testenv:lint]
 deps = pre-commit
 commands = pre-commit run --all-files
 skip_install = true
 passenv = PRE_COMMIT_COLOR
+
+[testenv:pins]
+extras = None
+commands_pre =
+    {envpython} -m pip install -r requirements.txt


### PR DESCRIPTION
Similar to https://github.com/hugovk/pypistats/pull/293.

https://nedbatchelder.com/code/cog

https://github.com/nedbat/cog

Update with:
```sh
python -m pip install cog
cog -Pr README.md
```

Or:
```sh
tox -e cog
```
