### PR TITLE
Add source URL to `--verbose`

### DIFF
--- a/src/norwegianblue/__init__.py
+++ b/src/norwegianblue/__init__.py
@@ -106,6 +106,11 @@ def norwegianblue(
         cache_file = _cache_filename(url)
         _print_verbose(verbose, f"Human URL:\thttps://endoflife.date/{product.lower()}")
         _print_verbose(verbose, f"API URL:\t{url}")
+        _print_verbose(
+            verbose,
+            "Source URL:\thttps://github.com/endoflife-date/endoflife.date/"
+            f"blob/master/products/{product.lower()}.md",
+        )
         _print_verbose(verbose, f"Cache file:\t{cache_file}")
 
         res = {}


### PR DESCRIPTION
```console
$ eol python -v
Human URL:	https://endoflife.date/python
API URL:	https://endoflife.date/api/python.json
Source URL:	https://github.com/endoflife-date/endoflife.date/blob/master/products/python.md
Cache file:	/Users/hugo/Library/Caches/norwegianblue/2021-12-07-https-endoflife-date-api-python-json.json
Cache file exists

| cycle | latest |  release   |    eol     |
|:------|:-------|:----------:|:----------:|
| 3.10  | 3.10.0 | 2021-10-04 | 2026-10-04 |
| 3.9   | 3.9.9  | 2020-10-05 | 2025-10-05 |
| 3.8   | 3.8.12 | 2019-10-14 | 2024-10-14 |
| 3.7   | 3.7.12 | 2018-06-27 | 2023-06-27 |
| 3.6   | 3.6.15 | 2016-12-23 | 2021-12-23 |
| 3.5   | 3.5.10 | 2015-09-30 | 2020-09-13 |
| 3.4   | 3.4.10 | 2014-03-16 | 2019-03-18 |
| 3.3   | 3.3.7  | 2012-09-29 | 2017-09-29 |
| 2.7   | 2.7.18 | 2010-07-03 | 2020-01-01 |
```

---

Note Source URL and API URL will be incorrect if a redirect was followed, for example:

```console
$ eol node -v
Human URL:	https://endoflife.date/node
API URL:	https://endoflife.date/api/node.json
Source URL:	https://github.com/endoflife-date/endoflife.date/blob/master/products/node.md
Cache file:	/Users/hugo/Library/Caches/norwegianblue/2021-12-07-https-endoflife-date-api-node-json.json
HTTP status code: 200

| cycle  | latest  |  release   |  support   |    eol     |
|:-------|:--------|:----------:|:----------:|:----------:|
| 17     | 17.2.0  | 2021-10-19 | 2022-04-01 | 2022-06-01 |
| 16 LTS | 16.13.1 | 2021-04-20 | 2022-10-18 | 2024-04-30 |
| 15     | 15.14.0 | 2020-10-20 | 2021-04-01 | 2021-06-01 |
| 14 LTS | 14.18.2 | 2020-04-21 | 2021-10-19 | 2023-04-30 |
| 12 LTS | 12.22.7 | 2019-04-23 | 2020-10-20 | 2022-04-30 |
| 10 LTS | 10.24.1 | 2018-04-24 | 2020-05-19 | 2021-04-30 |

$ eol nodejs -v
Human URL:	https://endoflife.date/nodejs
API URL:	https://endoflife.date/api/nodejs.json
Source URL:	https://github.com/endoflife-date/endoflife.date/blob/master/products/nodejs.md
Cache file:	/Users/hugo/Library/Caches/norwegianblue/2021-12-07-https-endoflife-date-api-nodejs-json.json
HTTP status code: 200

| cycle  | latest  |  release   |  support   |    eol     |
|:-------|:--------|:----------:|:----------:|:----------:|
| 17     | 17.2.0  | 2021-10-19 | 2022-04-01 | 2022-06-01 |
| 16 LTS | 16.13.1 | 2021-04-20 | 2022-10-18 | 2024-04-30 |
| 15     | 15.14.0 | 2020-10-20 | 2021-04-01 | 2021-06-01 |
| 14 LTS | 14.18.2 | 2020-04-21 | 2021-10-19 | 2023-04-30 |
| 12 LTS | 12.22.7 | 2019-04-23 | 2020-10-20 | 2022-04-30 |
| 10 LTS | 10.24.1 | 2018-04-24 | 2020-05-19 | 2021-04-30 |
```

HTTPX followed the `/node` -> `/nodejs` redirect in the first case. This could be fixed by checking `r.url` after `r = httpx.get(url, follow_redirects=True, headers={"User-Agent": USER_AGENT})`, but then we'd need to consider the cached cases too. Not a priority.
