### PR TITLE
Freeze time to fix colour test

### DIFF
--- a/tests/test_norwegianblue.py
+++ b/tests/test_norwegianblue.py
@@ -157,6 +157,7 @@ class TestNorwegianBlue:
         # Assert
         assert output.strip() == expected.strip()
 
+    @freeze_time("2021-09-13")
     @mock.patch.dict(os.environ, {"FORCE_COLOR": "TRUE"})
     @respx.mock
     def test_norwegianblue_force_color(self):


### PR DESCRIPTION
Dates are coloured based on the current time, and passed when this test was written.

Freeze time to match correct behaviour at that time.