### PR TITLE
Freeze time to fix test

### DIFF
--- a/tests/test_norwegianblue.py
+++ b/tests/test_norwegianblue.py
@@ -249,6 +249,7 @@ class TestNorwegianBlue:
         # Assert
         assert output == expected
 
+    @freeze_time("2021-06-16")
     def test__colourify_boolean_support(self) -> None:
         # Arrange
         data = [


### PR DESCRIPTION
A test started failing (e.g. https://github.com/hugovk/norwegianblue/pull/73) because time wasn't frozen and one product has moved from green to yellow.