### PR TITLE
Update for `release` renamed to `releaseDate` in API

### DIFF
--- a/src/norwegianblue/__init__.py
+++ b/src/norwegianblue/__init__.py
@@ -156,7 +156,15 @@ def _tabulate(data: list[dict], format: str = "markdown") -> str:
 
     # Put headers in preferred order, with the rest at the end
     new_headers = []
-    for preferred in ("cycle", "latest", "release", "support", "discontinued", "eol"):
+    for preferred in (
+        "cycle",
+        "releaseDate",
+        "latest",
+        "latestReleaseDate",
+        "support",
+        "discontinued",
+        "eol",
+    ):
         if preferred in headers:
             new_headers.append(preferred)
             headers.remove(preferred)

--- a/tests/data/expected_output.py
+++ b/tests/data/expected_output.py
@@ -3,68 +3,94 @@ EXPECTED_HTML = """
     <thead>
         <tr>
             <th>cycle</th>
+            <th>releaseDate</th>
             <th>latest</th>
-            <th>release</th>
             <th>support</th>
             <th>eol</th>
+            <th>codename</th>
             <th>link</th>
         </tr>
     </thead>
     <tbody>
         <tr>
-            <td align="left">21.04</td>
+            <td align="left">22.04 LTS</td>
+            <td align="left">2022-04-21</td>
+            <td align="left">22.04</td>
+            <td align="left">2027-04-02</td>
+            <td align="left">2032-04-01</td>
+            <td align="left">Jammy Jellyfish</td>
+            <td align="left">https://wiki.ubuntu.com/JammyJellyfish/ReleaseNotes/</td>
+        </tr>
+        <tr>
+            <td align="left">21.10</td>
+            <td align="left">2021-10-14</td>
+            <td align="left">21.10</td>
+            <td align="left">2022-07-31</td>
+            <td align="left">2022-07-31</td>
+            <td align="left">Impish Indri</td>
+            <td align="left">https://wiki.ubuntu.com/ImpishIndri/ReleaseNotes/</td>
+        </tr>
+        <tr>
             <td align="left">21.04</td>
             <td align="left">2021-04-22</td>
-            <td align="left">2022-01-01</td>
-            <td align="left">2022-01-01</td>
+            <td align="left">21.04</td>
+            <td align="left">2022-01-20</td>
+            <td align="left">2022-01-20</td>
+            <td align="left">Hirsute Hippo</td>
             <td align="left">https://wiki.ubuntu.com/HirsuteHippo/ReleaseNotes/</td>
         </tr>
         <tr>
             <td align="left">20.10</td>
-            <td align="left">20.10</td>
             <td align="left">2020-10-22</td>
-            <td align="left">2021-07-07</td>
-            <td align="left">2021-07-07</td>
-            <td align="left">https://wiki.ubuntu.com/GroovyGorilla/ReleaseNotes/</td>
+            <td align="left">20.10</td>
+            <td align="left">2021-07-22</td>
+            <td align="left">2021-07-22</td>
+            <td align="left">Groovy Gorilla</td>
+            <td align="left"></td>
         </tr>
         <tr>
             <td align="left">20.04 LTS</td>
-            <td align="left">20.04.2</td>
             <td align="left">2020-04-23</td>
-            <td align="left">2022-10-01</td>
+            <td align="left">20.04.4</td>
             <td align="left">2025-04-02</td>
+            <td align="left">2030-04-01</td>
+            <td align="left">Focal Fossa</td>
             <td align="left"></td>
         </tr>
         <tr>
             <td align="left">19.10</td>
-            <td align="left">19.10</td>
             <td align="left">2019-10-17</td>
+            <td align="left">19.10</td>
             <td align="left">2020-07-06</td>
             <td align="left">2020-07-06</td>
+            <td align="left">Karmic Koala</td>
             <td align="left"></td>
         </tr>
         <tr>
             <td align="left">18.04 LTS</td>
-            <td align="left">18.04.5</td>
             <td align="left">2018-04-26</td>
-            <td align="left">2020-09-30</td>
+            <td align="left">18.04.6</td>
             <td align="left">2023-04-02</td>
-            <td align="left"></td>
+            <td align="left">2028-04-01</td>
+            <td align="left">Bionic Beaver</td>
+            <td align="left">https://wiki.ubuntu.com/BionicBeaver/ReleaseNotes</td>
         </tr>
         <tr>
             <td align="left">16.04 LTS</td>
-            <td align="left">16.04.7</td>
             <td align="left">2016-04-21</td>
-            <td align="left">2018-10-01</td>
+            <td align="left">16.04.7</td>
             <td align="left">2021-04-02</td>
+            <td align="left">2026-04-01</td>
+            <td align="left">Xenial Xerus</td>
             <td align="left"></td>
         </tr>
         <tr>
             <td align="left">14.04 LTS</td>
-            <td align="left">14.04.6</td>
             <td align="left">2014-04-17</td>
-            <td align="left">2016-09-30</td>
+            <td align="left">14.04.6</td>
             <td align="left">2019-04-02</td>
+            <td align="left">2024-04-01</td>
+            <td align="left">Trusty Tahr</td>
             <td align="left"></td>
         </tr>
     </tbody>
@@ -72,54 +98,63 @@ EXPECTED_HTML = """
 """
 
 EXPECTED_MD = """
-| cycle     | latest  |  release   |  support   |    eol     | link                                                |
-|:----------|:--------|:----------:|:----------:|:----------:|:----------------------------------------------------|
-| 21.04     | 21.04   | 2021-04-22 | 2022-01-01 | 2022-01-01 | https://wiki.ubuntu.com/HirsuteHippo/ReleaseNotes/  |
-| 20.10     | 20.10   | 2020-10-22 | 2021-07-07 | 2021-07-07 | https://wiki.ubuntu.com/GroovyGorilla/ReleaseNotes/ |
-| 20.04 LTS | 20.04.2 | 2020-04-23 | 2022-10-01 | 2025-04-02 |                                                     |
-| 19.10     | 19.10   | 2019-10-17 | 2020-07-06 | 2020-07-06 |                                                     |
-| 18.04 LTS | 18.04.5 | 2018-04-26 | 2020-09-30 | 2023-04-02 |                                                     |
-| 16.04 LTS | 16.04.7 | 2016-04-21 | 2018-10-01 | 2021-04-02 |                                                     |
-| 14.04 LTS | 14.04.6 | 2014-04-17 | 2016-09-30 | 2019-04-02 |                                                     |
+| cycle     | releaseDate | latest  |  support   |    eol     |     codename    | link                                                 |
+|:----------|:-----------:|:--------|:----------:|:----------:|:---------------:|:-----------------------------------------------------|
+| 22.04 LTS |  2022-04-21 | 22.04   | 2027-04-02 | 2032-04-01 | Jammy Jellyfish | https://wiki.ubuntu.com/JammyJellyfish/ReleaseNotes/ |
+| 21.10     |  2021-10-14 | 21.10   | 2022-07-31 | 2022-07-31 |   Impish Indri  | https://wiki.ubuntu.com/ImpishIndri/ReleaseNotes/    |
+| 21.04     |  2021-04-22 | 21.04   | 2022-01-20 | 2022-01-20 |  Hirsute Hippo  | https://wiki.ubuntu.com/HirsuteHippo/ReleaseNotes/   |
+| 20.10     |  2020-10-22 | 20.10   | 2021-07-22 | 2021-07-22 |  Groovy Gorilla |                                                      |
+| 20.04 LTS |  2020-04-23 | 20.04.4 | 2025-04-02 | 2030-04-01 |   Focal Fossa   |                                                      |
+| 19.10     |  2019-10-17 | 19.10   | 2020-07-06 | 2020-07-06 |   Karmic Koala  |                                                      |
+| 18.04 LTS |  2018-04-26 | 18.04.6 | 2023-04-02 | 2028-04-01 |  Bionic Beaver  | https://wiki.ubuntu.com/BionicBeaver/ReleaseNotes    |
+| 16.04 LTS |  2016-04-21 | 16.04.7 | 2021-04-02 | 2026-04-01 |   Xenial Xerus  |                                                      |
+| 14.04 LTS |  2014-04-17 | 14.04.6 | 2019-04-02 | 2024-04-01 |   Trusty Tahr   |                                                      |
 """  # noqa: E501
 
 
 EXPECTED_MD_COLOUR = """
-| cycle     | latest  |  release   |  support   |    eol     | link                                                |
-|:----------|:--------|:----------:|:----------:|:----------:|:----------------------------------------------------|
-| 21.04     | 21.04   | 2021-04-22 | \x1b[33m2022-01-01\x1b[0m | \x1b[33m2022-01-01\x1b[0m | https://wiki.ubuntu.com/HirsuteHippo/ReleaseNotes/  |
-| 20.10     | 20.10   | 2020-10-22 | \x1b[31m2021-07-07\x1b[0m | \x1b[31m2021-07-07\x1b[0m | https://wiki.ubuntu.com/GroovyGorilla/ReleaseNotes/ |
-| 20.04 LTS | 20.04.2 | 2020-04-23 | \x1b[32m2022-10-01\x1b[0m | \x1b[32m2025-04-02\x1b[0m |                                                     |
-| 19.10     | 19.10   | 2019-10-17 | \x1b[31m2020-07-06\x1b[0m | \x1b[31m2020-07-06\x1b[0m |                                                     |
-| 18.04 LTS | 18.04.5 | 2018-04-26 | \x1b[31m2020-09-30\x1b[0m | \x1b[32m2023-04-02\x1b[0m |                                                     |
-| 16.04 LTS | 16.04.7 | 2016-04-21 | \x1b[31m2018-10-01\x1b[0m | \x1b[31m2021-04-02\x1b[0m |                                                     |
-| 14.04 LTS | 14.04.6 | 2014-04-17 | \x1b[31m2016-09-30\x1b[0m | \x1b[31m2019-04-02\x1b[0m |                                                     |
+| cycle     | releaseDate | latest  |  support   |    eol     |     codename    | link                                                 |
+|:----------|:-----------:|:--------|:----------:|:----------:|:---------------:|:-----------------------------------------------------|
+| 22.04 LTS |  2022-04-21 | 22.04   | [32m2027-04-02[0m | [32m2032-04-01[0m | Jammy Jellyfish | https://wiki.ubuntu.com/JammyJellyfish/ReleaseNotes/ |
+| 21.10     |  2021-10-14 | 21.10   | [32m2022-07-31[0m | [32m2022-07-31[0m |   Impish Indri  | https://wiki.ubuntu.com/ImpishIndri/ReleaseNotes/    |
+| 21.04     |  2021-04-22 | 21.04   | [33m2022-01-20[0m | [33m2022-01-20[0m |  Hirsute Hippo  | https://wiki.ubuntu.com/HirsuteHippo/ReleaseNotes/   |
+| 20.10     |  2020-10-22 | 20.10   | [31m2021-07-22[0m | [31m2021-07-22[0m |  Groovy Gorilla |                                                      |
+| 20.04 LTS |  2020-04-23 | 20.04.4 | [32m2025-04-02[0m | [32m2030-04-01[0m |   Focal Fossa   |                                                      |
+| 19.10     |  2019-10-17 | 19.10   | [31m2020-07-06[0m | [31m2020-07-06[0m |   Karmic Koala  |                                                      |
+| 18.04 LTS |  2018-04-26 | 18.04.6 | [32m2023-04-02[0m | [32m2028-04-01[0m |  Bionic Beaver  | https://wiki.ubuntu.com/BionicBeaver/ReleaseNotes    |
+| 16.04 LTS |  2016-04-21 | 16.04.7 | [31m2021-04-02[0m | [32m2026-04-01[0m |   Xenial Xerus  |                                                      |
+| 14.04 LTS |  2014-04-17 | 14.04.6 | [31m2019-04-02[0m | [32m2024-04-01[0m |   Trusty Tahr   |                                                      |
+
 """  # noqa: E501
 
 
 EXPECTED_RST = """
 .. table::
 
-    ===========  =========  ============  ============  ============  =====================================================
-       cycle      latest      release       support         eol                               link                         
-    ===========  =========  ============  ============  ============  =====================================================
-     21.04        21.04      2021-04-22    2022-01-01    2022-01-01    https://wiki.ubuntu.com/HirsuteHippo/ReleaseNotes/  
-     20.10        20.10      2020-10-22    2021-07-07    2021-07-07    https://wiki.ubuntu.com/GroovyGorilla/ReleaseNotes/ 
-     20.04 LTS    20.04.2    2020-04-23    2022-10-01    2025-04-02                                                        
-     19.10        19.10      2019-10-17    2020-07-06    2020-07-06                                                        
-     18.04 LTS    18.04.5    2018-04-26    2020-09-30    2023-04-02                                                        
-     16.04 LTS    16.04.7    2016-04-21    2018-10-01    2021-04-02                                                        
-     14.04 LTS    14.04.6    2014-04-17    2016-09-30    2019-04-02                                                        
-    ===========  =========  ============  ============  ============  =====================================================
+    ===========  =============  =========  ============  ============  =================  ======================================================
+       cycle      releaseDate    latest      support         eol           codename                                link                         
+    ===========  =============  =========  ============  ============  =================  ======================================================
+     22.04 LTS    2022-04-21     22.04      2027-04-02    2032-04-01    Jammy Jellyfish    https://wiki.ubuntu.com/JammyJellyfish/ReleaseNotes/ 
+     21.10        2021-10-14     21.10      2022-07-31    2022-07-31    Impish Indri       https://wiki.ubuntu.com/ImpishIndri/ReleaseNotes/    
+     21.04        2021-04-22     21.04      2022-01-20    2022-01-20    Hirsute Hippo      https://wiki.ubuntu.com/HirsuteHippo/ReleaseNotes/   
+     20.10        2020-10-22     20.10      2021-07-22    2021-07-22    Groovy Gorilla                                                          
+     20.04 LTS    2020-04-23     20.04.4    2025-04-02    2030-04-01    Focal Fossa                                                             
+     19.10        2019-10-17     19.10      2020-07-06    2020-07-06    Karmic Koala                                                            
+     18.04 LTS    2018-04-26     18.04.6    2023-04-02    2028-04-01    Bionic Beaver      https://wiki.ubuntu.com/BionicBeaver/ReleaseNotes    
+     16.04 LTS    2016-04-21     16.04.7    2021-04-02    2026-04-01    Xenial Xerus                                                            
+     14.04 LTS    2014-04-17     14.04.6    2019-04-02    2024-04-01    Trusty Tahr                                                             
+    ===========  =============  =========  ============  ============  =================  ======================================================
 """  # noqa: E501 W291
 
 EXPECTED_TSV = """
-"cycle"	"latest"	"release"	"support"	"eol"	"link"
-"21.04"	"21.04"	"2021-04-22"	"2022-01-01"	"2022-01-01"	"https://wiki.ubuntu.com/HirsuteHippo/ReleaseNotes/"
-"20.10"	"20.10"	"2020-10-22"	"2021-07-07"	"2021-07-07"	"https://wiki.ubuntu.com/GroovyGorilla/ReleaseNotes/"
-"20.04 LTS"	"20.04.2"	"2020-04-23"	"2022-10-01"	"2025-04-02"	
-"19.10"	"19.10"	"2019-10-17"	"2020-07-06"	"2020-07-06"	
-"18.04 LTS"	"18.04.5"	"2018-04-26"	"2020-09-30"	"2023-04-02"	
-"16.04 LTS"	"16.04.7"	"2016-04-21"	"2018-10-01"	"2021-04-02"	
-"14.04 LTS"	"14.04.6"	"2014-04-17"	"2016-09-30"	"2019-04-02"	
+"cycle"	"releaseDate"	"latest"	"support"	"eol"	"codename"	"link"
+"22.04 LTS"	"2022-04-21"	"22.04"	"2027-04-02"	"2032-04-01"	"Jammy Jellyfish"	"https://wiki.ubuntu.com/JammyJellyfish/ReleaseNotes/"
+"21.10"	"2021-10-14"	"21.10"	"2022-07-31"	"2022-07-31"	"Impish Indri"	"https://wiki.ubuntu.com/ImpishIndri/ReleaseNotes/"
+"21.04"	"2021-04-22"	"21.04"	"2022-01-20"	"2022-01-20"	"Hirsute Hippo"	"https://wiki.ubuntu.com/HirsuteHippo/ReleaseNotes/"
+"20.10"	"2020-10-22"	"20.10"	"2021-07-22"	"2021-07-22"	"Groovy Gorilla"	
+"20.04 LTS"	"2020-04-23"	"20.04.4"	"2025-04-02"	"2030-04-01"	"Focal Fossa"	
+"19.10"	"2019-10-17"	"19.10"	"2020-07-06"	"2020-07-06"	"Karmic Koala"	
+"18.04 LTS"	"2018-04-26"	"18.04.6"	"2023-04-02"	"2028-04-01"	"Bionic Beaver"	"https://wiki.ubuntu.com/BionicBeaver/ReleaseNotes"
+"16.04 LTS"	"2016-04-21"	"16.04.7"	"2021-04-02"	"2026-04-01"	"Xenial Xerus"	
+"14.04 LTS"	"2014-04-17"	"14.04.6"	"2019-04-02"	"2024-04-01"	"Trusty Tahr"	
 """  # noqa: E501 W291

--- a/tests/test_norwegianblue.py
+++ b/tests/test_norwegianblue.py
@@ -23,69 +23,87 @@ from .data.expected_output import (
 
 SAMPLE_RESPONSE_JSON = """
 [
-    {
-        "cycle": "21.04",
-        "cycleShortHand": "HirsuteHippo",
-        "lts": false,
-        "release": "2021-04-22",
-        "support": "2022-01-01",
-        "eol": "2022-01-01",
-        "latest": "21.04",
-        "link": "https://wiki.ubuntu.com/HirsuteHippo/ReleaseNotes/"
-    },
-    {
-        "cycle": "20.10",
-        "cycleShortHand": "GroovyGorilla",
-        "lts": false,
-        "release": "2020-10-22",
-        "support": "2021-07-07",
-        "eol": "2021-07-07",
-        "latest": "20.10",
-        "link": "https://wiki.ubuntu.com/GroovyGorilla/ReleaseNotes/"
-    },
-    {
-        "cycle": "20.04",
-        "cycleShortHand": "FocalFossa",
-        "lts": true,
-        "release": "2020-04-23",
-        "support": "2022-10-01",
-        "eol": "2025-04-02",
-        "latest": "20.04.2"
-    },
-    {
-        "cycle": "19.10",
-        "release": "2019-10-17",
-        "support": "2020-07-06",
-        "eol": "2020-07-06",
-        "latest": "19.10"
-    },
-    {
-        "cycle": "18.04",
-        "cycleShortHand": "BionicBeaver",
-        "lts": true,
-        "release": "2018-04-26",
-        "support": "2020-09-30",
-        "eol": "2023-04-02",
-        "latest": "18.04.5"
-    },
-    {
-        "cycle": "16.04",
-        "cycleShortHand": "XenialXerus",
-        "lts": true,
-        "release": "2016-04-21",
-        "support": "2018-10-01",
-        "eol": "2021-04-02",
-        "latest": "16.04.7"
-    },
-    {
-        "cycle": "14.04",
-        "cycleShortHand": "TrustyTahr",
-        "lts": true,
-        "release": "2014-04-17",
-        "support": "2016-09-30",
-        "eol": "2019-04-02",
-        "latest": "14.04.6"
-    }
+  {
+    "cycle": "22.04",
+    "codename": "Jammy Jellyfish",
+    "support": "2027-04-02",
+    "eol": "2032-04-01",
+    "lts": true,
+    "latest": "22.04",
+    "link": "https://wiki.ubuntu.com/JammyJellyfish/ReleaseNotes/",
+    "releaseDate": "2022-04-21"
+  },
+  {
+    "cycle": "21.10",
+    "codename": "Impish Indri",
+    "support": "2022-07-31",
+    "eol": "2022-07-31",
+    "latest": "21.10",
+    "link": "https://wiki.ubuntu.com/ImpishIndri/ReleaseNotes/",
+    "releaseDate": "2021-10-14"
+  },
+  {
+    "cycle": "21.04",
+    "codename": "Hirsute Hippo",
+    "support": "2022-01-20",
+    "eol": "2022-01-20",
+    "latest": "21.04",
+    "link": "https://wiki.ubuntu.com/HirsuteHippo/ReleaseNotes/",
+    "releaseDate": "2021-04-22"
+  },
+  {
+    "cycle": "20.10",
+    "codename": "Groovy Gorilla",
+    "support": "2021-07-22",
+    "eol": "2021-07-22",
+    "latest": "20.10",
+    "releaseDate": "2020-10-22"
+  },
+  {
+    "cycle": "20.04",
+    "codename": "Focal Fossa",
+    "lts": true,
+    "support": "2025-04-02",
+    "eol": "2030-04-01",
+    "latest": "20.04.4",
+    "releaseDate": "2020-04-23"
+  },
+  {
+    "cycle": "19.10",
+    "codename": "Karmic Koala",
+    "support": "2020-07-06",
+    "eol": "2020-07-06",
+    "latest": "19.10",
+    "releaseDate": "2019-10-17"
+  },
+  {
+    "cycle": "18.04",
+    "codename": "Bionic Beaver",
+    "lts": true,
+    "support": "2023-04-02",
+    "eol": "2028-04-01",
+    "latest": "18.04.6",
+    "link": "https://wiki.ubuntu.com/BionicBeaver/ReleaseNotes",
+    "releaseDate": "2018-04-26"
+  },
+  {
+    "cycle": "16.04",
+    "codename": "Xenial Xerus",
+    "lts": true,
+    "support": "2021-04-02",
+    "eol": "2026-04-01",
+    "latest": "16.04.7",
+    "releaseDate": "2016-04-21"
+  },
+  {
+    "cycle": "14.04",
+    "codename": "Trusty Tahr",
+    "lts": true,
+    "support": "2019-04-02",
+    "eol": "2024-04-01",
+    "latest": "14.04.6",
+    "releaseDate": "2014-04-17"
+  }
 ]
 """
 
@@ -131,7 +149,7 @@ class TestNorwegianBlue:
             pytest.param("tsv", EXPECTED_TSV, id="tsv"),
         ],
     )
-    def test_norwegianblue(self, test_format, expected) -> None:
+    def test_norwegianblue(self, test_format: str, expected: str) -> None:
         # Arrange
         mocked_url = "https://endoflife.date/api/ubuntu.json"
         mocked_response = SAMPLE_RESPONSE_JSON
@@ -382,7 +400,6 @@ class TestNorwegianBlue:
 
         # Act
         output = norwegianblue._colourify(data)
-        print(output)
 
         # Assert
         assert output == expected
@@ -426,7 +443,6 @@ class TestNorwegianBlue:
         output = norwegianblue.norwegianblue(product="norwegianblue")
 
         # Assert
-        print(output)
         assert "Norwegian Blue" in output
 
     def test__ltsify(self) -> None:


### PR DESCRIPTION
Following changes made in https://github.com/endoflife-date/endoflife.date/pull/1264.

Main thing is to re-order them to something sensible, and we also have a new `latestReleaseDate`.

Might rename headers in another PR, like `latestReleaseDate` to `latest release date` (or something shorter).

# Before

```console
$ eol python
[:~/github/norwegianblue] main* ± eol python
| cycle | latest |    eol     | latestReleaseDate | releaseDate |
|:------|:-------|:----------:|:-----------------:|:-----------:|
| 3.10  | 3.10.5 | 2026-10-04 |     2022-06-06    |  2021-10-04 |
| 3.9   | 3.9.13 | 2025-10-05 |     2022-05-17    |  2020-10-05 |
| 3.8   | 3.8.13 | 2024-10-14 |     2022-03-16    |  2019-10-14 |
| 3.7   | 3.7.13 | 2023-06-27 |     2022-03-16    |  2018-06-26 |
| 3.6   | 3.6.15 | 2021-12-23 |     2021-09-03    |  2016-12-22 |
| 3.5   | 3.5.10 | 2020-09-13 |     2020-09-05    |  2015-09-12 |
| 3.4   | 3.4.10 | 2019-03-18 |     2019-03-18    |  2014-03-15 |
| 3.3   | 3.3.7  | 2017-09-29 |     2017-09-19    |  2012-09-29 |
| 2.7   | 2.7.18 | 2020-01-01 |     2020-04-19    |  2010-07-03 |


```

```console
$ eol ubuntu
| cycle     | latest  |  support   |    eol     |     codename    | link                                                 | releaseDate |
|:----------|:--------|:----------:|:----------:|:---------------:|:-----------------------------------------------------|:-----------:|
| 22.04 LTS | 22.04   | 2027-04-02 | 2032-04-01 | Jammy Jellyfish | https://wiki.ubuntu.com/JammyJellyfish/ReleaseNotes/ |  2022-04-21 |
| 21.10     | 21.10   | 2022-07-31 | 2022-07-31 |   Impish Indri  | https://wiki.ubuntu.com/ImpishIndri/ReleaseNotes/    |  2021-10-14 |
| 21.04     | 21.04   | 2022-01-20 | 2022-01-20 |  Hirsute Hippo  | https://wiki.ubuntu.com/HirsuteHippo/ReleaseNotes/   |  2021-04-22 |
| 20.10     | 20.10   | 2021-07-22 | 2021-07-22 |  Groovy Gorilla |                                                      |  2020-10-22 |
| 20.04 LTS | 20.04.4 | 2025-04-02 | 2030-04-01 |   Focal Fossa   |                                                      |  2020-04-23 |
| 19.10     | 19.10   | 2020-07-06 | 2020-07-06 |   Karmic Koala  |                                                      |  2019-10-17 |
| 18.04 LTS | 18.04.6 | 2023-04-02 | 2028-04-01 |  Bionic Beaver  | https://wiki.ubuntu.com/BionicBeaver/ReleaseNotes    |  2018-04-26 |
| 16.04 LTS | 16.04.7 | 2021-04-02 | 2026-04-01 |   Xenial Xerus  |                                                      |  2016-04-21 |
| 14.04 LTS | 14.04.6 | 2019-04-02 | 2024-04-01 |   Trusty Tahr   |                                                      |  2014-04-17 |

```

# After

```console
$ eol python
| cycle | releaseDate | latest | latestReleaseDate |    eol     |
|:------|:-----------:|:-------|:-----------------:|:----------:|
| 3.10  |  2021-10-04 | 3.10.5 |     2022-06-06    | 2026-10-04 |
| 3.9   |  2020-10-05 | 3.9.13 |     2022-05-17    | 2025-10-05 |
| 3.8   |  2019-10-14 | 3.8.13 |     2022-03-16    | 2024-10-14 |
| 3.7   |  2018-06-26 | 3.7.13 |     2022-03-16    | 2023-06-27 |
| 3.6   |  2016-12-22 | 3.6.15 |     2021-09-03    | 2021-12-23 |
| 3.5   |  2015-09-12 | 3.5.10 |     2020-09-05    | 2020-09-13 |
| 3.4   |  2014-03-15 | 3.4.10 |     2019-03-18    | 2019-03-18 |
| 3.3   |  2012-09-29 | 3.3.7  |     2017-09-19    | 2017-09-29 |
| 2.7   |  2010-07-03 | 2.7.18 |     2020-04-19    | 2020-01-01 |

```

```console
$ eol ubuntu
| cycle     | releaseDate | latest  |  support   |    eol     |     codename    | link                                                 |
|:----------|:-----------:|:--------|:----------:|:----------:|:---------------:|:-----------------------------------------------------|
| 22.04 LTS |  2022-04-21 | 22.04   | 2027-04-02 | 2032-04-01 | Jammy Jellyfish | https://wiki.ubuntu.com/JammyJellyfish/ReleaseNotes/ |
| 21.10     |  2021-10-14 | 21.10   | 2022-07-31 | 2022-07-31 |   Impish Indri  | https://wiki.ubuntu.com/ImpishIndri/ReleaseNotes/    |
| 21.04     |  2021-04-22 | 21.04   | 2022-01-20 | 2022-01-20 |  Hirsute Hippo  | https://wiki.ubuntu.com/HirsuteHippo/ReleaseNotes/   |
| 20.10     |  2020-10-22 | 20.10   | 2021-07-22 | 2021-07-22 |  Groovy Gorilla |                                                      |
| 20.04 LTS |  2020-04-23 | 20.04.4 | 2025-04-02 | 2030-04-01 |   Focal Fossa   |                                                      |
| 19.10     |  2019-10-17 | 19.10   | 2020-07-06 | 2020-07-06 |   Karmic Koala  |                                                      |
| 18.04 LTS |  2018-04-26 | 18.04.6 | 2023-04-02 | 2028-04-01 |  Bionic Beaver  | https://wiki.ubuntu.com/BionicBeaver/ReleaseNotes    |
| 16.04 LTS |  2016-04-21 | 16.04.7 | 2021-04-02 | 2026-04-01 |   Xenial Xerus  |                                                      |
| 14.04 LTS |  2014-04-17 | 14.04.6 | 2019-04-02 | 2024-04-01 |   Trusty Tahr   |                                                      |

```
