### PR TITLE
Omit the releaseLabel column

### DIFF
--- a/src/norwegianblue/__init__.py
+++ b/src/norwegianblue/__init__.py
@@ -166,7 +166,7 @@ def _tabulate(data: list[dict], format: str = "markdown") -> str:
     headers = sorted(set().union(*(d.keys() for d in data)))
 
     # Skip some headers, only used internally at https://endoflife.date
-    for header in ("cycleShortHand", "latestShortHand"):
+    for header in ("cycleShortHand", "latestShortHand", "releaseLabel"):
         if header in headers:
             headers.remove(header)
 


### PR DESCRIPTION
# Webpage

https://endoflife.date/macos looks like:

<img width="770" alt="image" src="https://user-images.githubusercontent.com/1324225/192086331-f819fe6c-c05e-4ffb-b05f-9fff9bcb497a.png">

Note the newer ones are macOS: "macOS 10.12 (Sierra)" and older are OS X: "OS X 10.11 (El Capitan)".

# MD


https://raw.githubusercontent.com/endoflife-date/endoflife.date/master/products/macos.md looks like:


```md
---
title: macOS
alternate_urls:
-   /mac
category: os
sortReleasesBy: releaseDate
releaseLabel: "macOS __RELEASE_CYCLE__ (__CODENAME__)"
# Data: https://github.com/endoflife-date/release-data/blob/main/releases/macos.json
# Source: https://support.apple.com/en-us/HT201222 (and older versions linked at bottom)
# Script: https://github.com/endoflife-date/release-data/blob/main/src/apple.py
auto:
-   custom: true
releases:
-   releaseCycle: "12"
    codename: "Monterey"
    eol: false
    link: https://support.apple.com/HT212585
    releaseDate: 2021-10-25
    latestReleaseDate: 2022-09-12
    latest: '12.6'
-   releaseCycle: "11"
    codename: "Big Sur"
    eol: false
    link: https://support.apple.com/HT211896
    releaseDate: 2020-11-12
    latestReleaseDate: 2022-09-12
    latest: '11.7'
-   releaseCycle: "10.15"
    codename: "Catalina"
    eol: false
    link: https://support.apple.com/HT210642
    releaseDate: 2019-10-07
    latestReleaseDate: 2020-09-24
    latest: 10.15.7
-   releaseCycle: "10.14"
    codename: "Mojave"
    eol: 2021-10-25
    releaseDate: 2018-09-24
    latestReleaseDate: 2019-07-22
    latest: 10.14.6
-   releaseCycle: "10.13"
    codename: "High Sierra"
    eol: 2020-12-01
    releaseDate: 2017-09-25
    latestReleaseDate: 2018-07-09
    latest: 10.13.6
-   releaseCycle: "10.12"
    codename: "Sierra"
    eol: 2019-10-01
    releaseDate: 2016-09-20
    latestReleaseDate: 2017-07-19
    latest: 10.12.6
-   releaseCycle: "10.11"
    codename: "El Capitan"
    releaseLabel: "OS X __RELEASE_CYCLE__ (__CODENAME__)"
    eol: 2018-12-01
    releaseDate: 2015-09-30
    latestReleaseDate: 2016-07-18
    latest: 10.11.6
-   releaseCycle: "10.10"
    releaseLabel: "OS X __RELEASE_CYCLE__ (__CODENAME__)"
    codename: "Yosemite"
    eol: 2017-08-01
    releaseDate: 2014-10-16
    latestReleaseDate: 2015-08-13
    latest: 10.10.5
-   releaseCycle: "10.9"
    releaseLabel: "OS X __RELEASE_CYCLE__ (__CODENAME__)"
    codename: "Mavericks"
    eol: 2016-12-01
    releaseDate: 2013-10-22
    latestReleaseDate: 2014-09-17
    latest: 10.9.5
permalink: /macos
releasePolicyLink: https://developer.apple.com/documentation/macos-release-notes
activeSupportColumn: false
releaseColumn: true
releaseDateColumn: true
eolColumn: Service Status
versionCommand: sw_vers

---

>[macOS](https://en.wikipedia.org/wiki/MacOS) (aka OS X, Mac OS X) is the primary operating system for Apple's Mac computers.

Major versions of macOS are released once a year now, and usually maintained for three years. Apple usually provides security updates for the latest 3 releases, but this isn't consistenly applied and some security fixes aren't available for the non-latest releases.
.
```

Note the default `releaseLabel: "macOS __RELEASE_CYCLE__ (__CODENAME__)"` template at the top, and the older ones override it with `releaseLabel: "OS X __RELEASE_CYCLE__ (__CODENAME__)"`.


# JSON

https://endoflife.date/api/macos.json looks like:

```json
[
{
"cycle": "12",
"codename": "Monterey",
"eol": false,
"link": "https://support.apple.com/HT212585",
"releaseDate": "2021-10-25",
"latestReleaseDate": "2022-09-12",
"latest": "12.6"
},
{
"cycle": "11",
"codename": "Big Sur",
"eol": false,
"link": "https://support.apple.com/HT211896",
"releaseDate": "2020-11-12",
"latestReleaseDate": "2022-09-12",
"latest": "11.7"
},
{
"cycle": "10.15",
"codename": "Catalina",
"eol": false,
"link": "https://support.apple.com/HT210642",
"releaseDate": "2019-10-07",
"latestReleaseDate": "2020-09-24",
"latest": "10.15.7"
},
{
"cycle": "10.14",
"codename": "Mojave",
"eol": "2021-10-25",
"releaseDate": "2018-09-24",
"latestReleaseDate": "2019-07-22",
"latest": "10.14.6"
},
{
"cycle": "10.13",
"codename": "High Sierra",
"eol": "2020-12-01",
"releaseDate": "2017-09-25",
"latestReleaseDate": "2018-07-09",
"latest": "10.13.6"
},
{
"cycle": "10.12",
"codename": "Sierra",
"eol": "2019-10-01",
"releaseDate": "2016-09-20",
"latestReleaseDate": "2017-07-19",
"latest": "10.12.6"
},
{
"cycle": "10.11",
"codename": "El Capitan",
"releaseLabel": "OS X __RELEASE_CYCLE__ (__CODENAME__)",
"eol": "2018-12-01",
"releaseDate": "2015-09-30",
"latestReleaseDate": "2016-07-18",
"latest": "10.11.6"
},
{
"cycle": "10.10",
"releaseLabel": "OS X __RELEASE_CYCLE__ (__CODENAME__)",
"codename": "Yosemite",
"eol": "2017-08-01",
"releaseDate": "2014-10-16",
"latestReleaseDate": "2015-08-13",
"latest": "10.10.5"
},
{
"cycle": "10.9",
"releaseLabel": "OS X __RELEASE_CYCLE__ (__CODENAME__)",
"codename": "Mavericks",
"eol": "2016-12-01",
"releaseDate": "2013-10-22",
"latestReleaseDate": "2014-09-17",
"latest": "10.9.5"
}
]
```

Note only the older ones have `releaseLabel`, there's not yet any top-evel metadata in the API. This is planned for the future.

# eol

## Before

Includes `releaseLabel` for the older ones:

```console
$ eol macos
| cycle |  release   | latest  | latest release |    eol     |   codename  | link                               |              releaseLabel             |
|:------|:----------:|:--------|:--------------:|:----------:|:-----------:|:-----------------------------------|:-------------------------------------:|
| 12    | 2021-10-25 | 12.6    |   2022-09-12   |   False    |   Monterey  | https://support.apple.com/HT212585 |                                       |
| 11    | 2020-11-12 | 11.7    |   2022-09-12   |   False    |   Big Sur   | https://support.apple.com/HT211896 |                                       |
| 10.15 | 2019-10-07 | 10.15.7 |   2020-09-24   |   False    |   Catalina  | https://support.apple.com/HT210642 |                                       |
| 10.14 | 2018-09-24 | 10.14.6 |   2019-07-22   | 2021-10-25 |    Mojave   |                                    |                                       |
| 10.13 | 2017-09-25 | 10.13.6 |   2018-07-09   | 2020-12-01 | High Sierra |                                    |                                       |
| 10.12 | 2016-09-20 | 10.12.6 |   2017-07-19   | 2019-10-01 |    Sierra   |                                    |                                       |
| 10.11 | 2015-09-30 | 10.11.6 |   2016-07-18   | 2018-12-01 |  El Capitan |                                    | OS X __RELEASE_CYCLE__ (__CODENAME__) |
| 10.10 | 2014-10-16 | 10.10.5 |   2015-08-13   | 2017-08-01 |   Yosemite  |                                    | OS X __RELEASE_CYCLE__ (__CODENAME__) |
| 10.9  | 2013-10-22 | 10.9.5  |   2014-09-17   | 2016-12-01 |  Mavericks  |                                    | OS X __RELEASE_CYCLE__ (__CODENAME__) |
```

## After

Skip it:

```console
$ eol macos
| cycle |  release   | latest  | latest release |    eol     |   codename  | link                               |
|:------|:----------:|:--------|:--------------:|:----------:|:-----------:|:-----------------------------------|
| 12    | 2021-10-25 | 12.6    |   2022-09-12   |   False    |   Monterey  | https://support.apple.com/HT212585 |
| 11    | 2020-11-12 | 11.7    |   2022-09-12   |   False    |   Big Sur   | https://support.apple.com/HT211896 |
| 10.15 | 2019-10-07 | 10.15.7 |   2020-09-24   |   False    |   Catalina  | https://support.apple.com/HT210642 |
| 10.14 | 2018-09-24 | 10.14.6 |   2019-07-22   | 2021-10-25 |    Mojave   |                                    |
| 10.13 | 2017-09-25 | 10.13.6 |   2018-07-09   | 2020-12-01 | High Sierra |                                    |
| 10.12 | 2016-09-20 | 10.12.6 |   2017-07-19   | 2019-10-01 |    Sierra   |                                    |
| 10.11 | 2015-09-30 | 10.11.6 |   2016-07-18   | 2018-12-01 |  El Capitan |                                    |
| 10.10 | 2014-10-16 | 10.10.5 |   2015-08-13   | 2017-08-01 |   Yosemite  |                                    |
| 10.9  | 2013-10-22 | 10.9.5  |   2014-09-17   | 2016-12-01 |  Mavericks  |                                    |
```

# Future

When the API includes the top-level default `releaseLabel`, we can use the template to show display names.

Or we can ask the API to construct and include display names for us.
