### PR TITLE
termcolor now disables colour if not tty, but FORCE_COLOR for colour tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,4 @@ pytest==7.1.3
 pytest-cov==4.0.0
 python-slugify==6.1.2
 respx==0.20.0
-termcolor==2.0.1
+termcolor==2.1.0

--- a/tests/test_norwegianblue.py
+++ b/tests/test_norwegianblue.py
@@ -203,6 +203,7 @@ class TestNorwegianBlue:
                 "eol": "\x1b[32m2023-04-02\x1b[0m",  # green
             },
         ]
+        os.environ["FORCE_COLOR"] = "1"
 
         # Act
         output = norwegianblue._colourify(data)


### PR DESCRIPTION
Since https://github.com/termcolor/termcolor/releases/tag/2.1.0 and https://github.com/termcolor/termcolor/pull/25, we need to make sure colour is enabled for these tests.

Fixes failures seen in https://github.com/hugovk/norwegianblue/pull/103, https://github.com/hugovk/norwegianblue/pull/104, https://github.com/hugovk/norwegianblue/pull/105, https://github.com/hugovk/norwegianblue/pull/106.