### PR TITLE
Add CSV format output

### DIFF
--- a/src/norwegianblue/__init__.py
+++ b/src/norwegianblue/__init__.py
@@ -209,6 +209,7 @@ def _prettytable(headers: list[str], data: list[dict]) -> str:
 
 def _pytablewriter(headers: list[str], data: list[dict], format: str) -> str:
     from pytablewriter import (
+        CsvTableWriter,
         HtmlTableWriter,
         RstSimpleTableWriter,
         String,
@@ -217,6 +218,7 @@ def _pytablewriter(headers: list[str], data: list[dict], format: str) -> str:
     from pytablewriter.style import Align, Style
 
     format_writers = {
+        "csv": CsvTableWriter,
         "html": HtmlTableWriter,
         "rst": RstSimpleTableWriter,
         "tsv": TsvTableWriter,

--- a/src/norwegianblue/cli.py
+++ b/src/norwegianblue/cli.py
@@ -45,7 +45,7 @@ def main() -> None:
         "-f",
         "--format",
         default="markdown",
-        choices=("html", "json", "markdown", "rst", "tsv"),
+        choices=("html", "json", "markdown", "rst", "csv", "tsv"),
         help="The format of output",
     )
     parser.add_argument(

--- a/tests/data/expected_output.py
+++ b/tests/data/expected_output.py
@@ -147,6 +147,19 @@ EXPECTED_RST = """
     ===========  ============  =========  ============  ============  =================  ======================================================
 """  # noqa: E501 W291
 
+EXPECTED_CSV = """
+"cycle","release","latest","support","eol","codename","link"
+"22.04 LTS","2022-04-21","22.04","2027-04-02","2032-04-01","Jammy Jellyfish","https://wiki.ubuntu.com/JammyJellyfish/ReleaseNotes/"
+"21.10","2021-10-14","21.10","2022-07-31","2022-07-31","Impish Indri","https://wiki.ubuntu.com/ImpishIndri/ReleaseNotes/"
+"21.04","2021-04-22","21.04","2022-01-20","2022-01-20","Hirsute Hippo","https://wiki.ubuntu.com/HirsuteHippo/ReleaseNotes/"
+"20.10","2020-10-22","20.10","2021-07-22","2021-07-22","Groovy Gorilla",
+"20.04 LTS","2020-04-23","20.04.4","2025-04-02","2030-04-01","Focal Fossa",
+"19.10","2019-10-17","19.10","2020-07-06","2020-07-06","Karmic Koala",
+"18.04 LTS","2018-04-26","18.04.6","2023-04-02","2028-04-01","Bionic Beaver","https://wiki.ubuntu.com/BionicBeaver/ReleaseNotes"
+"16.04 LTS","2016-04-21","16.04.7","2021-04-02","2026-04-01","Xenial Xerus",
+"14.04 LTS","2014-04-17","14.04.6","2019-04-02","2024-04-01","Trusty Tahr",
+"""  # noqa: E501 W291
+
 EXPECTED_TSV = """
 "cycle"	"release"	"latest"	"support"	"eol"	"codename"	"link"
 "22.04 LTS"	"2022-04-21"	"22.04"	"2027-04-02"	"2032-04-01"	"Jammy Jellyfish"	"https://wiki.ubuntu.com/JammyJellyfish/ReleaseNotes/"

--- a/tests/test_norwegianblue.py
+++ b/tests/test_norwegianblue.py
@@ -16,6 +16,7 @@ import norwegianblue
 from norwegianblue import _cache
 
 from .data.expected_output import (
+    EXPECTED_CSV,
     EXPECTED_HTML,
     EXPECTED_MD,
     EXPECTED_MD_COLOUR,
@@ -57,6 +58,7 @@ class TestNorwegianBlue:
     @pytest.mark.parametrize(
         "test_format, expected",
         [
+            pytest.param("csv", EXPECTED_CSV, id="csv"),
             pytest.param("html", EXPECTED_HTML, id="html"),
             pytest.param("markdown", EXPECTED_MD, id="markdown"),
             pytest.param("rst", EXPECTED_RST, id="rst"),


### PR DESCRIPTION
Fixes #110.

Add CSV format output.

For example:

```console
$ eol python --format csv
"cycle","release","latest","latest release","eol"
"3.11","2022-10-24","3.11.0","2022-10-24","2027-10-24"
"3.10","2021-10-04","3.10.8","2022-10-11","2026-10-04"
"3.9","2020-10-05","3.9.15","2022-10-11","2025-10-05"
"3.8","2019-10-14","3.8.15","2022-10-11","2024-10-14"
"3.7","2018-06-26","3.7.15","2022-10-10","2023-06-27"
"3.6","2016-12-22","3.6.15","2021-09-03","2021-12-23"
"3.5","2015-09-12","3.5.10","2020-09-05","2020-09-13"
"3.4","2014-03-15","3.4.10","2019-03-18","2019-03-18"
"3.3","2012-09-29","3.3.7","2017-09-19","2017-09-29"
"2.7","2010-07-03","2.7.18","2020-04-19","2020-01-01"
"2.6","2008-10-01","2.6.9","2013-10-29","2013-10-29"
```