### PR TITLE
Output codename after cycle

### DIFF
--- a/src/norwegianblue/__init__.py
+++ b/src/norwegianblue/__init__.py
@@ -176,6 +176,7 @@ def _tabulate(data: list[dict], format_: str = "markdown") -> str:
     new_headers = []
     for preferred in (
         "cycle",
+        "codename",
         "release",
         "latest",
         "latest release",

--- a/tests/data/expected_output.py
+++ b/tests/data/expected_output.py
@@ -5,94 +5,94 @@ EXPECTED_HTML = """
     <thead>
         <tr>
             <th>cycle</th>
+            <th>codename</th>
             <th>release</th>
             <th>latest</th>
             <th>support</th>
             <th>eol</th>
-            <th>codename</th>
             <th>link</th>
         </tr>
     </thead>
     <tbody>
         <tr>
             <td align="left">22.04 LTS</td>
+            <td align="left">Jammy Jellyfish</td>
             <td align="left">2022-04-21</td>
             <td align="left">22.04</td>
             <td align="left">2027-04-02</td>
             <td align="left">2032-04-01</td>
-            <td align="left">Jammy Jellyfish</td>
             <td align="left">https://wiki.ubuntu.com/JammyJellyfish/ReleaseNotes/</td>
         </tr>
         <tr>
             <td align="left">21.10</td>
+            <td align="left">Impish Indri</td>
             <td align="left">2021-10-14</td>
             <td align="left">21.10</td>
             <td align="left">2022-07-31</td>
             <td align="left">2022-07-31</td>
-            <td align="left">Impish Indri</td>
             <td align="left">https://wiki.ubuntu.com/ImpishIndri/ReleaseNotes/</td>
         </tr>
         <tr>
             <td align="left">21.04</td>
+            <td align="left">Hirsute Hippo</td>
             <td align="left">2021-04-22</td>
             <td align="left">21.04</td>
             <td align="left">2022-01-20</td>
             <td align="left">2022-01-20</td>
-            <td align="left">Hirsute Hippo</td>
             <td align="left">https://wiki.ubuntu.com/HirsuteHippo/ReleaseNotes/</td>
         </tr>
         <tr>
             <td align="left">20.10</td>
+            <td align="left">Groovy Gorilla</td>
             <td align="left">2020-10-22</td>
             <td align="left">20.10</td>
             <td align="left">2021-07-22</td>
             <td align="left">2021-07-22</td>
-            <td align="left">Groovy Gorilla</td>
             <td align="left"></td>
         </tr>
         <tr>
             <td align="left">20.04 LTS</td>
+            <td align="left">Focal Fossa</td>
             <td align="left">2020-04-23</td>
             <td align="left">20.04.4</td>
             <td align="left">2025-04-02</td>
             <td align="left">2030-04-01</td>
-            <td align="left">Focal Fossa</td>
             <td align="left"></td>
         </tr>
         <tr>
             <td align="left">19.10</td>
+            <td align="left">Karmic Koala</td>
             <td align="left">2019-10-17</td>
             <td align="left">19.10</td>
             <td align="left">2020-07-06</td>
             <td align="left">2020-07-06</td>
-            <td align="left">Karmic Koala</td>
             <td align="left"></td>
         </tr>
         <tr>
             <td align="left">18.04 LTS</td>
+            <td align="left">Bionic Beaver</td>
             <td align="left">2018-04-26</td>
             <td align="left">18.04.6</td>
             <td align="left">2023-04-02</td>
             <td align="left">2028-04-01</td>
-            <td align="left">Bionic Beaver</td>
             <td align="left">https://wiki.ubuntu.com/BionicBeaver/ReleaseNotes</td>
         </tr>
         <tr>
             <td align="left">16.04 LTS</td>
+            <td align="left">Xenial Xerus</td>
             <td align="left">2016-04-21</td>
             <td align="left">16.04.7</td>
             <td align="left">2021-04-02</td>
             <td align="left">2026-04-01</td>
-            <td align="left">Xenial Xerus</td>
             <td align="left"></td>
         </tr>
         <tr>
             <td align="left">14.04 LTS</td>
+            <td align="left">Trusty Tahr</td>
             <td align="left">2014-04-17</td>
             <td align="left">14.04.6</td>
             <td align="left">2019-04-02</td>
             <td align="left">2024-04-01</td>
-            <td align="left">Trusty Tahr</td>
             <td align="left"></td>
         </tr>
     </tbody>
@@ -100,92 +100,92 @@ EXPECTED_HTML = """
 """
 
 EXPECTED_MD = """
-| cycle     |  release   | latest  |  support   |    eol     |     codename    | link                                                 |
-|:----------|:----------:|:--------|:----------:|:----------:|:---------------:|:-----------------------------------------------------|
-| 22.04 LTS | 2022-04-21 | 22.04   | 2027-04-02 | 2032-04-01 | Jammy Jellyfish | https://wiki.ubuntu.com/JammyJellyfish/ReleaseNotes/ |
-| 21.10     | 2021-10-14 | 21.10   | 2022-07-31 | 2022-07-31 |   Impish Indri  | https://wiki.ubuntu.com/ImpishIndri/ReleaseNotes/    |
-| 21.04     | 2021-04-22 | 21.04   | 2022-01-20 | 2022-01-20 |  Hirsute Hippo  | https://wiki.ubuntu.com/HirsuteHippo/ReleaseNotes/   |
-| 20.10     | 2020-10-22 | 20.10   | 2021-07-22 | 2021-07-22 |  Groovy Gorilla |                                                      |
-| 20.04 LTS | 2020-04-23 | 20.04.4 | 2025-04-02 | 2030-04-01 |   Focal Fossa   |                                                      |
-| 19.10     | 2019-10-17 | 19.10   | 2020-07-06 | 2020-07-06 |   Karmic Koala  |                                                      |
-| 18.04 LTS | 2018-04-26 | 18.04.6 | 2023-04-02 | 2028-04-01 |  Bionic Beaver  | https://wiki.ubuntu.com/BionicBeaver/ReleaseNotes    |
-| 16.04 LTS | 2016-04-21 | 16.04.7 | 2021-04-02 | 2026-04-01 |   Xenial Xerus  |                                                      |
-| 14.04 LTS | 2014-04-17 | 14.04.6 | 2019-04-02 | 2024-04-01 |   Trusty Tahr   |                                                      |
+| cycle     |     codename    |  release   | latest  |  support   |    eol     | link                                                 |
+|:----------|:---------------:|:----------:|:--------|:----------:|:----------:|:-----------------------------------------------------|
+| 22.04 LTS | Jammy Jellyfish | 2022-04-21 | 22.04   | 2027-04-02 | 2032-04-01 | https://wiki.ubuntu.com/JammyJellyfish/ReleaseNotes/ |
+| 21.10     |   Impish Indri  | 2021-10-14 | 21.10   | 2022-07-31 | 2022-07-31 | https://wiki.ubuntu.com/ImpishIndri/ReleaseNotes/    |
+| 21.04     |  Hirsute Hippo  | 2021-04-22 | 21.04   | 2022-01-20 | 2022-01-20 | https://wiki.ubuntu.com/HirsuteHippo/ReleaseNotes/   |
+| 20.10     |  Groovy Gorilla | 2020-10-22 | 20.10   | 2021-07-22 | 2021-07-22 |                                                      |
+| 20.04 LTS |   Focal Fossa   | 2020-04-23 | 20.04.4 | 2025-04-02 | 2030-04-01 |                                                      |
+| 19.10     |   Karmic Koala  | 2019-10-17 | 19.10   | 2020-07-06 | 2020-07-06 |                                                      |
+| 18.04 LTS |  Bionic Beaver  | 2018-04-26 | 18.04.6 | 2023-04-02 | 2028-04-01 | https://wiki.ubuntu.com/BionicBeaver/ReleaseNotes    |
+| 16.04 LTS |   Xenial Xerus  | 2016-04-21 | 16.04.7 | 2021-04-02 | 2026-04-01 |                                                      |
+| 14.04 LTS |   Trusty Tahr   | 2014-04-17 | 14.04.6 | 2019-04-02 | 2024-04-01 |                                                      |
 """  # noqa: E501
 
 
 EXPECTED_MD_COLOUR = """
-| cycle     |  release   | latest  |  support   |    eol     |     codename    | link                                                 |
-|:----------|:----------:|:--------|:----------:|:----------:|:---------------:|:-----------------------------------------------------|
-| 22.04 LTS | 2022-04-21 | 22.04   | [32m2027-04-02[0m | [32m2032-04-01[0m | Jammy Jellyfish | https://wiki.ubuntu.com/JammyJellyfish/ReleaseNotes/ |
-| 21.10     | 2021-10-14 | 21.10   | [32m2022-07-31[0m | [32m2022-07-31[0m |   Impish Indri  | https://wiki.ubuntu.com/ImpishIndri/ReleaseNotes/    |
-| 21.04     | 2021-04-22 | 21.04   | [33m2022-01-20[0m | [33m2022-01-20[0m |  Hirsute Hippo  | https://wiki.ubuntu.com/HirsuteHippo/ReleaseNotes/   |
-| 20.10     | 2020-10-22 | 20.10   | [31m2021-07-22[0m | [31m2021-07-22[0m |  Groovy Gorilla |                                                      |
-| 20.04 LTS | 2020-04-23 | 20.04.4 | [32m2025-04-02[0m | [32m2030-04-01[0m |   Focal Fossa   |                                                      |
-| 19.10     | 2019-10-17 | 19.10   | [31m2020-07-06[0m | [31m2020-07-06[0m |   Karmic Koala  |                                                      |
-| 18.04 LTS | 2018-04-26 | 18.04.6 | [32m2023-04-02[0m | [32m2028-04-01[0m |  Bionic Beaver  | https://wiki.ubuntu.com/BionicBeaver/ReleaseNotes    |
-| 16.04 LTS | 2016-04-21 | 16.04.7 | [31m2021-04-02[0m | [32m2026-04-01[0m |   Xenial Xerus  |                                                      |
-| 14.04 LTS | 2014-04-17 | 14.04.6 | [31m2019-04-02[0m | [32m2024-04-01[0m |   Trusty Tahr   |                                                      |
+| cycle     |     codename    |  release   | latest  |  support   |    eol     | link                                                 |
+|:----------|:---------------:|:----------:|:--------|:----------:|:----------:|:-----------------------------------------------------|
+| 22.04 LTS | Jammy Jellyfish | 2022-04-21 | 22.04   | \x1b[32m2027-04-02\x1b[0m | \x1b[32m2032-04-01\x1b[0m | https://wiki.ubuntu.com/JammyJellyfish/ReleaseNotes/ |
+| 21.10     |   Impish Indri  | 2021-10-14 | 21.10   | \x1b[32m2022-07-31\x1b[0m | \x1b[32m2022-07-31\x1b[0m | https://wiki.ubuntu.com/ImpishIndri/ReleaseNotes/    |
+| 21.04     |  Hirsute Hippo  | 2021-04-22 | 21.04   | \x1b[33m2022-01-20\x1b[0m | \x1b[33m2022-01-20\x1b[0m | https://wiki.ubuntu.com/HirsuteHippo/ReleaseNotes/   |
+| 20.10     |  Groovy Gorilla | 2020-10-22 | 20.10   | \x1b[31m2021-07-22\x1b[0m | \x1b[31m2021-07-22\x1b[0m |                                                      |
+| 20.04 LTS |   Focal Fossa   | 2020-04-23 | 20.04.4 | \x1b[32m2025-04-02\x1b[0m | \x1b[32m2030-04-01\x1b[0m |                                                      |
+| 19.10     |   Karmic Koala  | 2019-10-17 | 19.10   | \x1b[31m2020-07-06\x1b[0m | \x1b[31m2020-07-06\x1b[0m |                                                      |
+| 18.04 LTS |  Bionic Beaver  | 2018-04-26 | 18.04.6 | \x1b[32m2023-04-02\x1b[0m | \x1b[32m2028-04-01\x1b[0m | https://wiki.ubuntu.com/BionicBeaver/ReleaseNotes    |
+| 16.04 LTS |   Xenial Xerus  | 2016-04-21 | 16.04.7 | \x1b[31m2021-04-02\x1b[0m | \x1b[32m2026-04-01\x1b[0m |                                                      |
+| 14.04 LTS |   Trusty Tahr   | 2014-04-17 | 14.04.6 | \x1b[31m2019-04-02\x1b[0m | \x1b[32m2024-04-01\x1b[0m |                                                      |
 """  # noqa: E501
 
 EXPECTED_PRETTY = """
-┌───────────┬────────────┬─────────┬────────────┬────────────┬─────────────────┬──────────────────────────────────────────────────────┐
-│ cycle     │  release   │ latest  │  support   │    eol     │     codename    │ link                                                 │
-├───────────┼────────────┼─────────┼────────────┼────────────┼─────────────────┼──────────────────────────────────────────────────────┤
-│ 22.04 LTS │ 2022-04-21 │ 22.04   │ 2027-04-02 │ 2032-04-01 │ Jammy Jellyfish │ https://wiki.ubuntu.com/JammyJellyfish/ReleaseNotes/ │
-│ 21.10     │ 2021-10-14 │ 21.10   │ 2022-07-31 │ 2022-07-31 │   Impish Indri  │ https://wiki.ubuntu.com/ImpishIndri/ReleaseNotes/    │
-│ 21.04     │ 2021-04-22 │ 21.04   │ 2022-01-20 │ 2022-01-20 │  Hirsute Hippo  │ https://wiki.ubuntu.com/HirsuteHippo/ReleaseNotes/   │
-│ 20.10     │ 2020-10-22 │ 20.10   │ 2021-07-22 │ 2021-07-22 │  Groovy Gorilla │                                                      │
-│ 20.04 LTS │ 2020-04-23 │ 20.04.4 │ 2025-04-02 │ 2030-04-01 │   Focal Fossa   │                                                      │
-│ 19.10     │ 2019-10-17 │ 19.10   │ 2020-07-06 │ 2020-07-06 │   Karmic Koala  │                                                      │
-│ 18.04 LTS │ 2018-04-26 │ 18.04.6 │ 2023-04-02 │ 2028-04-01 │  Bionic Beaver  │ https://wiki.ubuntu.com/BionicBeaver/ReleaseNotes    │
-│ 16.04 LTS │ 2016-04-21 │ 16.04.7 │ 2021-04-02 │ 2026-04-01 │   Xenial Xerus  │                                                      │
-│ 14.04 LTS │ 2014-04-17 │ 14.04.6 │ 2019-04-02 │ 2024-04-01 │   Trusty Tahr   │                                                      │
-└───────────┴────────────┴─────────┴────────────┴────────────┴─────────────────┴──────────────────────────────────────────────────────┘
+┌───────────┬─────────────────┬────────────┬─────────┬────────────┬────────────┬──────────────────────────────────────────────────────┐
+│ cycle     │     codename    │  release   │ latest  │  support   │    eol     │ link                                                 │
+├───────────┼─────────────────┼────────────┼─────────┼────────────┼────────────┼──────────────────────────────────────────────────────┤
+│ 22.04 LTS │ Jammy Jellyfish │ 2022-04-21 │ 22.04   │ 2027-04-02 │ 2032-04-01 │ https://wiki.ubuntu.com/JammyJellyfish/ReleaseNotes/ │
+│ 21.10     │   Impish Indri  │ 2021-10-14 │ 21.10   │ 2022-07-31 │ 2022-07-31 │ https://wiki.ubuntu.com/ImpishIndri/ReleaseNotes/    │
+│ 21.04     │  Hirsute Hippo  │ 2021-04-22 │ 21.04   │ 2022-01-20 │ 2022-01-20 │ https://wiki.ubuntu.com/HirsuteHippo/ReleaseNotes/   │
+│ 20.10     │  Groovy Gorilla │ 2020-10-22 │ 20.10   │ 2021-07-22 │ 2021-07-22 │                                                      │
+│ 20.04 LTS │   Focal Fossa   │ 2020-04-23 │ 20.04.4 │ 2025-04-02 │ 2030-04-01 │                                                      │
+│ 19.10     │   Karmic Koala  │ 2019-10-17 │ 19.10   │ 2020-07-06 │ 2020-07-06 │                                                      │
+│ 18.04 LTS │  Bionic Beaver  │ 2018-04-26 │ 18.04.6 │ 2023-04-02 │ 2028-04-01 │ https://wiki.ubuntu.com/BionicBeaver/ReleaseNotes    │
+│ 16.04 LTS │   Xenial Xerus  │ 2016-04-21 │ 16.04.7 │ 2021-04-02 │ 2026-04-01 │                                                      │
+│ 14.04 LTS │   Trusty Tahr   │ 2014-04-17 │ 14.04.6 │ 2019-04-02 │ 2024-04-01 │                                                      │
+└───────────┴─────────────────┴────────────┴─────────┴────────────┴────────────┴──────────────────────────────────────────────────────┘
 """  # noqa: E501
 
 EXPECTED_RST = """
 .. table::
 
-    ===========  ============  =========  ============  ============  =================  ======================================================
-       cycle       release      latest      support         eol           codename                                link                         
-    ===========  ============  =========  ============  ============  =================  ======================================================
-     22.04 LTS    2022-04-21    22.04      2027-04-02    2032-04-01    Jammy Jellyfish    https://wiki.ubuntu.com/JammyJellyfish/ReleaseNotes/ 
-     21.10        2021-10-14    21.10      2022-07-31    2022-07-31    Impish Indri       https://wiki.ubuntu.com/ImpishIndri/ReleaseNotes/    
-     21.04        2021-04-22    21.04      2022-01-20    2022-01-20    Hirsute Hippo      https://wiki.ubuntu.com/HirsuteHippo/ReleaseNotes/   
-     20.10        2020-10-22    20.10      2021-07-22    2021-07-22    Groovy Gorilla                                                          
-     20.04 LTS    2020-04-23    20.04.4    2025-04-02    2030-04-01    Focal Fossa                                                             
-     19.10        2019-10-17    19.10      2020-07-06    2020-07-06    Karmic Koala                                                            
-     18.04 LTS    2018-04-26    18.04.6    2023-04-02    2028-04-01    Bionic Beaver      https://wiki.ubuntu.com/BionicBeaver/ReleaseNotes    
-     16.04 LTS    2016-04-21    16.04.7    2021-04-02    2026-04-01    Xenial Xerus                                                            
-     14.04 LTS    2014-04-17    14.04.6    2019-04-02    2024-04-01    Trusty Tahr                                                             
-    ===========  ============  =========  ============  ============  =================  ======================================================
+    ===========  =================  ============  =========  ============  ============  ======================================================
+       cycle         codename         release      latest      support         eol                                link                         
+    ===========  =================  ============  =========  ============  ============  ======================================================
+     22.04 LTS    Jammy Jellyfish    2022-04-21    22.04      2027-04-02    2032-04-01    https://wiki.ubuntu.com/JammyJellyfish/ReleaseNotes/ 
+     21.10        Impish Indri       2021-10-14    21.10      2022-07-31    2022-07-31    https://wiki.ubuntu.com/ImpishIndri/ReleaseNotes/    
+     21.04        Hirsute Hippo      2021-04-22    21.04      2022-01-20    2022-01-20    https://wiki.ubuntu.com/HirsuteHippo/ReleaseNotes/   
+     20.10        Groovy Gorilla     2020-10-22    20.10      2021-07-22    2021-07-22                                                         
+     20.04 LTS    Focal Fossa        2020-04-23    20.04.4    2025-04-02    2030-04-01                                                         
+     19.10        Karmic Koala       2019-10-17    19.10      2020-07-06    2020-07-06                                                         
+     18.04 LTS    Bionic Beaver      2018-04-26    18.04.6    2023-04-02    2028-04-01    https://wiki.ubuntu.com/BionicBeaver/ReleaseNotes    
+     16.04 LTS    Xenial Xerus       2016-04-21    16.04.7    2021-04-02    2026-04-01                                                         
+     14.04 LTS    Trusty Tahr        2014-04-17    14.04.6    2019-04-02    2024-04-01                                                         
+    ===========  =================  ============  =========  ============  ============  ======================================================
 """  # noqa: E501 W291
 
 EXPECTED_CSV = """
-"cycle","release","latest","support","eol","codename","link"
-"22.04 LTS","2022-04-21","22.04","2027-04-02","2032-04-01","Jammy Jellyfish","https://wiki.ubuntu.com/JammyJellyfish/ReleaseNotes/"
-"21.10","2021-10-14","21.10","2022-07-31","2022-07-31","Impish Indri","https://wiki.ubuntu.com/ImpishIndri/ReleaseNotes/"
-"21.04","2021-04-22","21.04","2022-01-20","2022-01-20","Hirsute Hippo","https://wiki.ubuntu.com/HirsuteHippo/ReleaseNotes/"
-"20.10","2020-10-22","20.10","2021-07-22","2021-07-22","Groovy Gorilla",
-"20.04 LTS","2020-04-23","20.04.4","2025-04-02","2030-04-01","Focal Fossa",
-"19.10","2019-10-17","19.10","2020-07-06","2020-07-06","Karmic Koala",
-"18.04 LTS","2018-04-26","18.04.6","2023-04-02","2028-04-01","Bionic Beaver","https://wiki.ubuntu.com/BionicBeaver/ReleaseNotes"
-"16.04 LTS","2016-04-21","16.04.7","2021-04-02","2026-04-01","Xenial Xerus",
-"14.04 LTS","2014-04-17","14.04.6","2019-04-02","2024-04-01","Trusty Tahr",
+"cycle","codename","release","latest","support","eol","link"
+"22.04 LTS","Jammy Jellyfish","2022-04-21","22.04","2027-04-02","2032-04-01","https://wiki.ubuntu.com/JammyJellyfish/ReleaseNotes/"
+"21.10","Impish Indri","2021-10-14","21.10","2022-07-31","2022-07-31","https://wiki.ubuntu.com/ImpishIndri/ReleaseNotes/"
+"21.04","Hirsute Hippo","2021-04-22","21.04","2022-01-20","2022-01-20","https://wiki.ubuntu.com/HirsuteHippo/ReleaseNotes/"
+"20.10","Groovy Gorilla","2020-10-22","20.10","2021-07-22","2021-07-22",
+"20.04 LTS","Focal Fossa","2020-04-23","20.04.4","2025-04-02","2030-04-01",
+"19.10","Karmic Koala","2019-10-17","19.10","2020-07-06","2020-07-06",
+"18.04 LTS","Bionic Beaver","2018-04-26","18.04.6","2023-04-02","2028-04-01","https://wiki.ubuntu.com/BionicBeaver/ReleaseNotes"
+"16.04 LTS","Xenial Xerus","2016-04-21","16.04.7","2021-04-02","2026-04-01",
+"14.04 LTS","Trusty Tahr","2014-04-17","14.04.6","2019-04-02","2024-04-01",
 """  # noqa: E501 W291
 
 EXPECTED_TSV = """
-"cycle"	"release"	"latest"	"support"	"eol"	"codename"	"link"
-"22.04 LTS"	"2022-04-21"	"22.04"	"2027-04-02"	"2032-04-01"	"Jammy Jellyfish"	"https://wiki.ubuntu.com/JammyJellyfish/ReleaseNotes/"
-"21.10"	"2021-10-14"	"21.10"	"2022-07-31"	"2022-07-31"	"Impish Indri"	"https://wiki.ubuntu.com/ImpishIndri/ReleaseNotes/"
-"21.04"	"2021-04-22"	"21.04"	"2022-01-20"	"2022-01-20"	"Hirsute Hippo"	"https://wiki.ubuntu.com/HirsuteHippo/ReleaseNotes/"
-"20.10"	"2020-10-22"	"20.10"	"2021-07-22"	"2021-07-22"	"Groovy Gorilla"	
-"20.04 LTS"	"2020-04-23"	"20.04.4"	"2025-04-02"	"2030-04-01"	"Focal Fossa"	
-"19.10"	"2019-10-17"	"19.10"	"2020-07-06"	"2020-07-06"	"Karmic Koala"	
-"18.04 LTS"	"2018-04-26"	"18.04.6"	"2023-04-02"	"2028-04-01"	"Bionic Beaver"	"https://wiki.ubuntu.com/BionicBeaver/ReleaseNotes"
-"16.04 LTS"	"2016-04-21"	"16.04.7"	"2021-04-02"	"2026-04-01"	"Xenial Xerus"	
-"14.04 LTS"	"2014-04-17"	"14.04.6"	"2019-04-02"	"2024-04-01"	"Trusty Tahr"	
+"cycle"\t"codename"\t"release"\t"latest"\t"support"\t"eol"\t"link"
+"22.04 LTS"\t"Jammy Jellyfish"\t"2022-04-21"\t"22.04"\t"2027-04-02"\t"2032-04-01"\t"https://wiki.ubuntu.com/JammyJellyfish/ReleaseNotes/"
+"21.10"\t"Impish Indri"\t"2021-10-14"\t"21.10"\t"2022-07-31"\t"2022-07-31"\t"https://wiki.ubuntu.com/ImpishIndri/ReleaseNotes/"
+"21.04"\t"Hirsute Hippo"\t"2021-04-22"\t"21.04"\t"2022-01-20"\t"2022-01-20"\t"https://wiki.ubuntu.com/HirsuteHippo/ReleaseNotes/"
+"20.10"\t"Groovy Gorilla"\t"2020-10-22"\t"20.10"\t"2021-07-22"\t"2021-07-22"\t
+"20.04 LTS"\t"Focal Fossa"\t"2020-04-23"\t"20.04.4"\t"2025-04-02"\t"2030-04-01"\t
+"19.10"\t"Karmic Koala"\t"2019-10-17"\t"19.10"\t"2020-07-06"\t"2020-07-06"\t
+"18.04 LTS"\t"Bionic Beaver"\t"2018-04-26"\t"18.04.6"\t"2023-04-02"\t"2028-04-01"\t"https://wiki.ubuntu.com/BionicBeaver/ReleaseNotes"
+"16.04 LTS"\t"Xenial Xerus"\t"2016-04-21"\t"16.04.7"\t"2021-04-02"\t"2026-04-01"\t
+"14.04 LTS"\t"Trusty Tahr"\t"2014-04-17"\t"14.04.6"\t"2019-04-02"\t"2024-04-01"\t
 """  # noqa: E501 W291
 
 EXPECTED_MD_LOG4J = """


### PR DESCRIPTION
Better to show the codename (e.g. "Jammy Jellyfish") after the cycle name (e.g. "22.04 LTS"), also more closely matches https://endoflife.date/ubuntu

# Before

```console
$ eol ubuntu
┌───────────┬────────────┬─────────┬────────────────┬────────────┬────────────┬─────────────────┬──────────────────────────────────────────────────────┐
│ cycle     │  release   │ latest  │ latest release │  support   │    eol     │     codename    │ link                                                 │
├───────────┼────────────┼─────────┼────────────────┼────────────┼────────────┼─────────────────┼──────────────────────────────────────────────────────┤
│ 22.10     │ 2022-10-20 │ 22.10   │   2022-10-20   │ 2023-07-20 │ 2023-07-20 │   Kinetic Kudu  │ https://wiki.ubuntu.com/KineticKudu/ReleaseNotes/    │
│ 22.04 LTS │ 2022-04-21 │ 22.04.1 │   2022-08-11   │ 2027-04-21 │ 2032-04-01 │ Jammy Jellyfish │ https://wiki.ubuntu.com/JammyJellyfish/ReleaseNotes/ │
│ 21.10     │ 2021-10-14 │ 21.10   │   2021-10-14   │ 2022-07-14 │ 2022-07-14 │   Impish Indri  │ https://wiki.ubuntu.com/ImpishIndri/ReleaseNotes/    │
│ 21.04     │ 2021-04-22 │ 21.04   │   2021-04-22   │ 2022-01-20 │ 2022-01-20 │  Hirsute Hippo  │ https://wiki.ubuntu.com/HirsuteHippo/ReleaseNotes/   │
│ 20.10     │ 2020-10-22 │ 20.10   │   2020-10-22   │ 2021-07-22 │ 2021-07-22 │  Groovy Gorilla │                                                      │
│ 20.04 LTS │ 2020-04-23 │ 20.04.5 │   2022-09-01   │ 2025-04-02 │ 2030-04-01 │   Focal Fossa   │                                                      │
│ 19.10     │ 2019-10-17 │ 19.10   │   2019-10-17   │ 2020-07-06 │ 2020-07-06 │   Karmic Koala  │                                                      │
│ 18.04 LTS │ 2018-04-26 │ 18.04.6 │   2021-09-17   │ 2023-04-02 │ 2028-04-01 │  Bionic Beaver  │ https://wiki.ubuntu.com/BionicBeaver/ReleaseNotes    │
│ 16.04 LTS │ 2016-04-21 │ 16.04.7 │   2020-08-13   │ 2021-04-02 │ 2026-04-01 │   Xenial Xerus  │                                                      │
│ 14.04 LTS │ 2014-04-17 │ 14.04.6 │   2019-03-07   │ 2019-04-02 │ 2024-04-01 │   Trusty Tahr   │                                                      │
└───────────┴────────────┴─────────┴────────────────┴────────────┴────────────┴─────────────────┴──────────────────────────────────────────────────────┘
```

# After

```console
$ eol ubuntu
┌───────────┬─────────────────┬────────────┬─────────┬────────────────┬────────────┬────────────┬──────────────────────────────────────────────────────┐
│ cycle     │     codename    │  release   │ latest  │ latest release │  support   │    eol     │ link                                                 │
├───────────┼─────────────────┼────────────┼─────────┼────────────────┼────────────┼────────────┼──────────────────────────────────────────────────────┤
│ 22.10     │   Kinetic Kudu  │ 2022-10-20 │ 22.10   │   2022-10-20   │ 2023-07-20 │ 2023-07-20 │ https://wiki.ubuntu.com/KineticKudu/ReleaseNotes/    │
│ 22.04 LTS │ Jammy Jellyfish │ 2022-04-21 │ 22.04.1 │   2022-08-11   │ 2027-04-21 │ 2032-04-01 │ https://wiki.ubuntu.com/JammyJellyfish/ReleaseNotes/ │
│ 21.10     │   Impish Indri  │ 2021-10-14 │ 21.10   │   2021-10-14   │ 2022-07-14 │ 2022-07-14 │ https://wiki.ubuntu.com/ImpishIndri/ReleaseNotes/    │
│ 21.04     │  Hirsute Hippo  │ 2021-04-22 │ 21.04   │   2021-04-22   │ 2022-01-20 │ 2022-01-20 │ https://wiki.ubuntu.com/HirsuteHippo/ReleaseNotes/   │
│ 20.10     │  Groovy Gorilla │ 2020-10-22 │ 20.10   │   2020-10-22   │ 2021-07-22 │ 2021-07-22 │                                                      │
│ 20.04 LTS │   Focal Fossa   │ 2020-04-23 │ 20.04.5 │   2022-09-01   │ 2025-04-02 │ 2030-04-01 │                                                      │
│ 19.10     │   Karmic Koala  │ 2019-10-17 │ 19.10   │   2019-10-17   │ 2020-07-06 │ 2020-07-06 │                                                      │
│ 18.04 LTS │  Bionic Beaver  │ 2018-04-26 │ 18.04.6 │   2021-09-17   │ 2023-04-02 │ 2028-04-01 │ https://wiki.ubuntu.com/BionicBeaver/ReleaseNotes    │
│ 16.04 LTS │   Xenial Xerus  │ 2016-04-21 │ 16.04.7 │   2020-08-13   │ 2021-04-02 │ 2026-04-01 │                                                      │
│ 14.04 LTS │   Trusty Tahr   │ 2014-04-17 │ 14.04.6 │   2019-03-07   │ 2019-04-02 │ 2024-04-01 │                                                      │
└───────────┴─────────────────┴────────────┴─────────┴────────────────┴────────────┴────────────┴──────────────────────────────────────────────────────┘
```
