### PR TITLE
Let termcolor 2.1 determine if colour can be used

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["pypy-3.8", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12-dev"]
+        python-version: ["pypy3.9", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12-dev"]
         os: [windows-latest, macos-latest, ubuntu-latest]
 
     steps:
@@ -35,8 +35,7 @@ jobs:
           tox -e py
 
       - name: Tox tests (pins)
-        if: matrix.python-version == '3.10' && matrix.os == 'ubuntu-latest'
-        shell: bash
+        if: matrix.python-version == '3.11' && matrix.os == 'ubuntu-latest'
         run: |
           tox -e pins
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
   "pytablewriter[html]>=0.63",
   "python-dateutil",
   "python-slugify",
-  "termcolor",
+  "termcolor>=2.1",
 ]
 dynamic = [
   "version",

--- a/tests/test_norwegianblue.py
+++ b/tests/test_norwegianblue.py
@@ -355,14 +355,6 @@ class TestNorwegianBlue:
         # Assert
         assert output == expected
 
-    @mock.patch.dict(os.environ, {"NO_COLOR": "TRUE"})
-    def test_no_color(self) -> None:
-        assert norwegianblue._can_do_colour() is False
-
-    @mock.patch.dict(os.environ, {"FORCE_COLOR": "TRUE"})
-    def test_force_color(self) -> None:
-        assert norwegianblue._can_do_colour() is True
-
     @respx.mock
     def test_all_products(self) -> None:
         # Arrange


### PR DESCRIPTION
https://github.com/termcolor/termcolor/releases/tag/2.1.0 added support to detect if colour can be used by the terminal, so we can depend on `termcolor>2.1` and remove that code from here.

Also bump PyPy3.8 to PyPy3.9 on CI.