### PR TITLE
Update pre-commit: Black and pyproject-fmt changes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
         args: [--py37-plus]
 
   - repo: https://github.com/psf/black
-    rev: 22.12.0
+    rev: 23.1.0
     hooks:
       - id: black
         args: [--target-version=py37]
@@ -24,7 +24,7 @@ repos:
         additional_dependencies: [flake8-2020, flake8-implicit-str-concat]
 
   - repo: https://github.com/pre-commit/pygrep-hooks
-    rev: v1.9.0
+    rev: v1.10.0
     hooks:
       - id: python-check-blanket-noqa
 
@@ -38,17 +38,17 @@ repos:
       - id: requirements-txt-fixer
 
   - repo: https://github.com/tox-dev/pyproject-fmt
-    rev: 0.4.1
+    rev: 0.6.0
     hooks:
       - id: pyproject-fmt
 
   - repo: https://github.com/abravalheri/validate-pyproject
-    rev: v0.10.1
+    rev: v0.12.1
     hooks:
       - id: validate-pyproject
 
   - repo: https://github.com/tox-dev/tox-ini-fmt
-    rev: 0.5.2
+    rev: 0.6.1
     hooks:
       - id: tox-ini-fmt
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,19 +17,6 @@ keywords = [
 license = {text = "MIT"}
 authors = [{name = "Hugo van Kemenade"}]
 requires-python = ">=3.7"
-dependencies = [
-  "httpx>=0.19",
-  'importlib-metadata; python_version < "3.8"',
-  "platformdirs",
-  "prettytable>=2.4",
-  "pytablewriter[html]>=0.63",
-  "python-dateutil",
-  "python-slugify",
-  "termcolor>=2.1",
-]
-dynamic = [
-  "version",
-]
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Developers",
@@ -46,6 +33,19 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",
+]
+dynamic = [
+  "version",
+]
+dependencies = [
+  "httpx>=0.19",
+  'importlib-metadata; python_version < "3.8"',
+  "platformdirs",
+  "prettytable>=2.4",
+  "pytablewriter[html]>=0.63",
+  "python-dateutil",
+  "python-slugify",
+  "termcolor>=2.1",
 ]
 [project.optional-dependencies]
 tests = [
@@ -64,9 +64,6 @@ Source = "https://github.com/hugovk/norwegianblue"
 eol = "norwegianblue.cli:main"
 norwegianblue = "norwegianblue.cli:main"
 
-
-[tool.black]
-target_version = ["py37"]
 
 [tool.hatch]
 version.source = "vcs"


### PR DESCRIPTION
The new Black can autodetect the target version from `project.requires-python` in `pyproject.toml`.

https://ichard26.github.io/blog/2023/01/black-23.1.0/#better-default-for---target-version-if-pep-621-python-requires-is-available