### PR TITLE
If product not found, offer a suggestion

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ dependencies = [
   "python-dateutil",
   "python-slugify",
   "termcolor>=2.1",
+  "thefuzz",
 ]
 [project.optional-dependencies]
 tests = [

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ pytest-cov==4.0.0
 python-slugify==8.0.0
 respx==0.20.1
 termcolor==2.2.0
+thefuzz==0.19.0

--- a/src/norwegianblue/__init__.py
+++ b/src/norwegianblue/__init__.py
@@ -63,7 +63,7 @@ def norwegianblue(
 
         logging.info("HTTP status code: %d", r.status_code)
         if r.status_code == 404:
-            return ERROR_404_TEXT
+            raise ValueError(ERROR_404_TEXT)
 
         # Raise if we made a bad request
         # (4XX client error or 5XX server error response)

--- a/src/norwegianblue/__init__.py
+++ b/src/norwegianblue/__init__.py
@@ -27,7 +27,7 @@ __all__ = ["__version__"]
 
 BASE_URL = "https://endoflife.date/api/"
 USER_AGENT = f"norwegianblue/{__version__}"
-ERROR_404_TEXT = "Product not found, run 'eol all' for list"
+ERROR_404_TEXT = "Product '{}' not found, run 'eol all' for list. Did you mean: '{}'?"
 
 
 def norwegianblue(
@@ -63,7 +63,8 @@ def norwegianblue(
 
         logging.info("HTTP status code: %d", r.status_code)
         if r.status_code == 404:
-            raise ValueError(ERROR_404_TEXT)
+            suggestion = _suggest_product(product)
+            raise ValueError(ERROR_404_TEXT.format(product, suggestion))
 
         # Raise if we made a bad request
         # (4XX client error or 5XX server error response)
@@ -92,6 +93,22 @@ def norwegianblue(
         return prefix + output
 
     return output
+
+
+def _suggest_product(product: str) -> str:
+    import warnings
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", category=UserWarning)
+        from thefuzz import process
+
+    # Get all known products from the API or cache
+    all_products = norwegianblue("all").splitlines()
+
+    # Find the closest match
+    result = process.extractOne(product, all_products)
+    logging.info("Suggestion:\t%s (score: %d)", *result)
+    return result[0]
 
 
 def _ltsify(data: list[dict]) -> list[dict]:

--- a/src/norwegianblue/cli.py
+++ b/src/norwegianblue/cli.py
@@ -81,11 +81,12 @@ def main() -> None:
         _cache.clear(clear_all=True)
 
     for product in args.product:
-        output = norwegianblue.norwegianblue(
-            product=product, format=args.format, color=args.color
-        )
-        if output == norwegianblue.ERROR_404_TEXT:
-            sys.exit(output)
+        try:
+            output = norwegianblue.norwegianblue(
+                product=product, format=args.format, color=args.color
+            )
+        except ValueError as e:
+            sys.exit(e)
         print(output)
         print()
 

--- a/tests/test_norwegianblue.py
+++ b/tests/test_norwegianblue.py
@@ -374,12 +374,10 @@ class TestNorwegianBlue:
         # Arrange
         mocked_url = "https://endoflife.date/api/this-product-not-found.json"
 
-        # Act
+        # Act / Assert
         respx.get(mocked_url).respond(status_code=404)
-        output = norwegianblue.norwegianblue(product="this-product-not-found")
-
-        # Assert
-        assert output.strip() == norwegianblue.ERROR_404_TEXT
+        with pytest.raises(ValueError, match=norwegianblue.ERROR_404_TEXT):
+            norwegianblue.norwegianblue(product="this-product-not-found")
 
     def test_norwegianblue_norwegianblue(self) -> None:
         # Act

--- a/tests/test_norwegianblue.py
+++ b/tests/test_norwegianblue.py
@@ -372,12 +372,20 @@ class TestNorwegianBlue:
     @respx.mock
     def test_404(self) -> None:
         # Arrange
-        mocked_url = "https://endoflife.date/api/this-product-not-found.json"
+        mocked_url = "https://endoflife.date/api/androd.json"
+        respx.get(mocked_url).respond(status_code=404)
+
+        mocked_url = "https://endoflife.date/api/all.json"
+        mocked_response = SAMPLE_RESPONSE_ALL_JSON
+        respx.get(mocked_url).respond(content=mocked_response)
 
         # Act / Assert
-        respx.get(mocked_url).respond(status_code=404)
-        with pytest.raises(ValueError, match=norwegianblue.ERROR_404_TEXT):
-            norwegianblue.norwegianblue(product="this-product-not-found")
+        with pytest.raises(
+            ValueError,
+            match=r"Product 'androd' not found, run 'eol all' for list\. "
+            r"Did you mean: 'android'?",
+        ):
+            norwegianblue.norwegianblue(product="androd")
 
     def test_norwegianblue_norwegianblue(self) -> None:
         # Act


### PR DESCRIPTION
If the product is not found, suggest the closest one.

For example:

```console
$ eol androd
Product 'androd' not found, run 'eol all' for list. Did you mean: 'android'?
$ eol pythn
Product 'pythn' not found, run 'eol all' for list. Did you mean: 'python'?
$ eol samsung
Product 'samsung' not found, run 'eol all' for list. Did you mean: 'samsung-mobile'?
```

Similar to the improved error messages in Python [3.10](https://docs.python.org/3/whatsnew/3.10.html#attributeerrors) and [3.12](https://docs.python.org/3.12/whatsnew/3.12.html#improved-error-messages). 

Also refactor `norwegianblue()` to raise `ValueError` on 404 instead of returning.

