### PR TITLE
Replace deprecated utcnow() with now(utc)

### DIFF
--- a/src/norwegianblue/__init__.py
+++ b/src/norwegianblue/__init__.py
@@ -153,7 +153,9 @@ def _colourify(data: list[dict]) -> list[dict]:
             # Handle date
             date_str = cycle[property_]
             # Convert "2020-01-01" string to datetime
-            date_datetime = dt.datetime.strptime(date_str, "%Y-%m-%d")
+            date_datetime = dt.datetime.strptime(date_str, "%Y-%m-%d").replace(
+                tzinfo=dt.timezone.utc
+            )
             if date_datetime < now:
                 cycle[property_] = colored(date_str, "red")
             elif date_datetime < six_months_from_now:

--- a/src/norwegianblue/__init__.py
+++ b/src/norwegianblue/__init__.py
@@ -133,7 +133,7 @@ def _colourify(data: list[dict]) -> list[dict]:
     yellow: will pass in six months
     green: will pass after six months
     """
-    now = dt.datetime.utcnow()
+    now = dt.datetime.now(dt.timezone.utc)
     six_months_from_now = now + relativedelta(months=+6)
 
     for cycle in data:

--- a/src/norwegianblue/_cache.py
+++ b/src/norwegianblue/_cache.py
@@ -16,7 +16,7 @@ def filename(url: str) -> Path:
     """yyyy-mm-dd-url-slug.json"""
     from slugify import slugify
 
-    today = dt.datetime.utcnow().strftime("%Y-%m-%d")
+    today = dt.datetime.now(dt.timezone.utc).strftime("%Y-%m-%d")
     slug = slugify(url)
     return CACHE_DIR / f"{today}-{slug}.json"
 
@@ -51,7 +51,7 @@ def save(cache_file: Path, data) -> None:
 def clear(clear_all: bool = False) -> None:
     """Delete all or old cache files"""
     cache_files = CACHE_DIR.glob("**/*.json")
-    today = dt.datetime.utcnow().strftime("%Y-%m-%d")
+    today = dt.datetime.now(dt.timezone.utc).strftime("%Y-%m-%d")
     for cache_file in cache_files:
         if clear_all or not cache_file.name.startswith(today):
             cache_file.unlink()


### PR DESCRIPTION
Raises a deprecation warning in Python 3.12: https://github.com/python/cpython/issues/103857.

Committed via https://github.com/asottile/all-repos