### PR TITLE
Fix left alignment of cycle column when header is bold for pretty format

### DIFF
--- a/src/norwegianblue/__init__.py
+++ b/src/norwegianblue/__init__.py
@@ -221,10 +221,13 @@ def _prettytable(
     do_color = color != "no" and format_ == "pretty"
 
     for header in headers:
+        left_align = header in ("cycle", "latest", "link")
+        display_header = colored(header, attrs=["bold"]) if do_color else header
         col_data = [row[header] if header in row else "" for row in data]
-        x.add_column(colored(header, attrs=["bold"]) if do_color else header, col_data)
-        if header in ("cycle", "latest", "link"):
-            x.align[header] = "l"
+        x.add_column(display_header, col_data)
+
+        if left_align:
+            x.align[display_header] = "l"
 
     title_prefix = ""
     if title:


### PR DESCRIPTION
Fixes https://github.com/hugovk/norwegianblue/issues/154.

This fixes a bug. The "cycle" and "latest" columns should be left aligned (for at least Markdown and pretty formats).

But when using pretty format, the headers are shown in bold, which means the alignment isn't set correctly because we've already modified the header text to add ANSI formatting.


# Before

The Markdown format correctly left aligns the cycle and latest columns:

```console
❯ eol ubuntu --format md
| cycle     |      codename     |  release   | latest  | latest release |  support   |    eol     | extendedSupport |
|:----------|:-----------------:|:----------:|:--------|:--------------:|:----------:|:----------:|:---------------:|
| 23.04     |   Lunar Lobster   | 2023-04-20 | 23.04   |   2023-04-20   | 2024-01-20 | 2024-01-20 |      False      |
| 22.10     |    Kinetic Kudu   | 2022-10-20 | 22.10   |   2022-10-20   | 2023-07-20 | 2023-07-20 |      False      |
| 22.04 LTS |  Jammy Jellyfish  | 2022-04-21 | 22.04.2 |   2023-02-24   | 2024-09-30 | 2027-04-01 |    2032-04-09   |
| 21.10     |    Impish Indri   | 2021-10-14 | 21.10   |   2021-10-14   | 2022-07-14 | 2022-07-14 |      False      |
| 21.04     |   Hirsute Hippo   | 2021-04-22 | 21.04   |   2021-04-22   | 2022-01-20 | 2022-01-20 |      False      |
| 20.10     |   Groovy Gorilla  | 2020-10-22 | 20.10   |   2020-10-22   | 2021-07-22 | 2021-07-22 |      False      |
| 20.04 LTS |    Focal Fossa    | 2020-04-23 | 20.04.6 |   2023-03-23   | 2022-10-01 | 2025-04-02 |    2030-04-02   |
| 19.10     |    Eoan Ermine    | 2019-10-17 | 19.10   |   2019-10-17   | 2020-07-06 | 2020-07-06 |      False      |
| 19.04     |    Disco Dingo    | 2019-04-18 | 19.04   |   2019-04-18   | 2020-01-23 | 2020-01-23 |      False      |
| 18.10     | Cosmic Cuttlefish | 2018-10-18 | 18.10   |   2018-10-18   | 2019-07-18 | 2019-07-18 |      False      |
| 18.04 LTS |   Bionic Beaver   | 2018-04-26 | 18.04.6 |   2021-09-17   | 2023-05-31 | 2023-05-31 |    2028-04-01   |
| 17.10     |  Artful Aardvark  | 2017-10-19 | 17.10   |   2017-10-19   | 2018-07-19 | 2018-07-19 |      False      |
| 17.04     |    Zesty Zapus    | 2017-04-13 | 17.04   |   2017-04-13   | 2018-01-13 | 2018-01-13 |      False      |
| 16.04 LTS |    Xenial Xerus   | 2016-04-21 | 16.04.7 |   2020-08-13   | 2021-04-02 | 2021-04-02 |    2026-04-02   |
| 15.10     |   Wily Werewolf   | 2015-10-22 | 15.10   |   2015-10-22   | 2016-07-28 | 2016-07-28 |      False      |
| 15.04     |    Vivid Vervet   | 2015-04-23 | 15.04   |   2015-04-23   | 2016-02-04 | 2016-02-04 |      False      |
| 14.10     |   Utopic Unicorn  | 2014-10-23 | 14.10   |   2014-10-23   | 2015-07-23 | 2015-07-23 |      False      |
| 14.04 LTS |    Trusty Tahr    | 2014-04-17 | 14.04.6 |   2019-03-07   | 2019-04-02 | 2019-04-02 |    2024-04-02   |
| 12.04 LTS |  Precise Pangolin | 2012-04-26 | 12.04.5 |   2014-08-08   | 2017-04-28 | 2017-04-28 |    2019-04-26   |
```

But not the pretty format. Not shown in the copy/paste, the headers are bold in the terminal:

```console
❯ eol ubuntu
┌───────────┬───────────────────┬────────────┬─────────┬────────────────┬────────────┬────────────┬─────────────────┐
│   cycle   │      codename     │  release   │  latest │ latest release │  support   │    eol     │ extendedSupport │
├───────────┼───────────────────┼────────────┼─────────┼────────────────┼────────────┼────────────┼─────────────────┤
│   23.04   │   Lunar Lobster   │ 2023-04-20 │  23.04  │   2023-04-20   │ 2024-01-20 │ 2024-01-20 │      False      │
│   22.10   │    Kinetic Kudu   │ 2022-10-20 │  22.10  │   2022-10-20   │ 2023-07-20 │ 2023-07-20 │      False      │
│ 22.04 LTS │  Jammy Jellyfish  │ 2022-04-21 │ 22.04.2 │   2023-02-24   │ 2024-09-30 │ 2027-04-01 │    2032-04-09   │
│   21.10   │    Impish Indri   │ 2021-10-14 │  21.10  │   2021-10-14   │ 2022-07-14 │ 2022-07-14 │      False      │
│   21.04   │   Hirsute Hippo   │ 2021-04-22 │  21.04  │   2021-04-22   │ 2022-01-20 │ 2022-01-20 │      False      │
│   20.10   │   Groovy Gorilla  │ 2020-10-22 │  20.10  │   2020-10-22   │ 2021-07-22 │ 2021-07-22 │      False      │
│ 20.04 LTS │    Focal Fossa    │ 2020-04-23 │ 20.04.6 │   2023-03-23   │ 2022-10-01 │ 2025-04-02 │    2030-04-02   │
│   19.10   │    Eoan Ermine    │ 2019-10-17 │  19.10  │   2019-10-17   │ 2020-07-06 │ 2020-07-06 │      False      │
│   19.04   │    Disco Dingo    │ 2019-04-18 │  19.04  │   2019-04-18   │ 2020-01-23 │ 2020-01-23 │      False      │
│   18.10   │ Cosmic Cuttlefish │ 2018-10-18 │  18.10  │   2018-10-18   │ 2019-07-18 │ 2019-07-18 │      False      │
│ 18.04 LTS │   Bionic Beaver   │ 2018-04-26 │ 18.04.6 │   2021-09-17   │ 2023-05-31 │ 2023-05-31 │    2028-04-01   │
│   17.10   │  Artful Aardvark  │ 2017-10-19 │  17.10  │   2017-10-19   │ 2018-07-19 │ 2018-07-19 │      False      │
│   17.04   │    Zesty Zapus    │ 2017-04-13 │  17.04  │   2017-04-13   │ 2018-01-13 │ 2018-01-13 │      False      │
│ 16.04 LTS │    Xenial Xerus   │ 2016-04-21 │ 16.04.7 │   2020-08-13   │ 2021-04-02 │ 2021-04-02 │    2026-04-02   │
│   15.10   │   Wily Werewolf   │ 2015-10-22 │  15.10  │   2015-10-22   │ 2016-07-28 │ 2016-07-28 │      False      │
│   15.04   │    Vivid Vervet   │ 2015-04-23 │  15.04  │   2015-04-23   │ 2016-02-04 │ 2016-02-04 │      False      │
│   14.10   │   Utopic Unicorn  │ 2014-10-23 │  14.10  │   2014-10-23   │ 2015-07-23 │ 2015-07-23 │      False      │
│ 14.04 LTS │    Trusty Tahr    │ 2014-04-17 │ 14.04.6 │   2019-03-07   │ 2019-04-02 │ 2019-04-02 │    2024-04-02   │
│ 12.04 LTS │  Precise Pangolin │ 2012-04-26 │ 12.04.5 │   2014-08-08   │ 2017-04-28 │ 2017-04-28 │    2019-04-26   │
└───────────┴───────────────────┴────────────┴─────────┴────────────────┴────────────┴────────────┴─────────────────┘
```


# After

Both are left aligned:

```console
❯ eol ubuntu --format md
| cycle     |      codename     |  release   | latest  | latest release |  support   |    eol     | extendedSupport |
|:----------|:-----------------:|:----------:|:--------|:--------------:|:----------:|:----------:|:---------------:|
| 23.04     |   Lunar Lobster   | 2023-04-20 | 23.04   |   2023-04-20   | 2024-01-20 | 2024-01-20 |      False      |
| 22.10     |    Kinetic Kudu   | 2022-10-20 | 22.10   |   2022-10-20   | 2023-07-20 | 2023-07-20 |      False      |
| 22.04 LTS |  Jammy Jellyfish  | 2022-04-21 | 22.04.2 |   2023-02-24   | 2024-09-30 | 2027-04-01 |    2032-04-09   |
| 21.10     |    Impish Indri   | 2021-10-14 | 21.10   |   2021-10-14   | 2022-07-14 | 2022-07-14 |      False      |
| 21.04     |   Hirsute Hippo   | 2021-04-22 | 21.04   |   2021-04-22   | 2022-01-20 | 2022-01-20 |      False      |
| 20.10     |   Groovy Gorilla  | 2020-10-22 | 20.10   |   2020-10-22   | 2021-07-22 | 2021-07-22 |      False      |
| 20.04 LTS |    Focal Fossa    | 2020-04-23 | 20.04.6 |   2023-03-23   | 2022-10-01 | 2025-04-02 |    2030-04-02   |
| 19.10     |    Eoan Ermine    | 2019-10-17 | 19.10   |   2019-10-17   | 2020-07-06 | 2020-07-06 |      False      |
| 19.04     |    Disco Dingo    | 2019-04-18 | 19.04   |   2019-04-18   | 2020-01-23 | 2020-01-23 |      False      |
| 18.10     | Cosmic Cuttlefish | 2018-10-18 | 18.10   |   2018-10-18   | 2019-07-18 | 2019-07-18 |      False      |
| 18.04 LTS |   Bionic Beaver   | 2018-04-26 | 18.04.6 |   2021-09-17   | 2023-05-31 | 2023-05-31 |    2028-04-01   |
| 17.10     |  Artful Aardvark  | 2017-10-19 | 17.10   |   2017-10-19   | 2018-07-19 | 2018-07-19 |      False      |
| 17.04     |    Zesty Zapus    | 2017-04-13 | 17.04   |   2017-04-13   | 2018-01-13 | 2018-01-13 |      False      |
| 16.04 LTS |    Xenial Xerus   | 2016-04-21 | 16.04.7 |   2020-08-13   | 2021-04-02 | 2021-04-02 |    2026-04-02   |
| 15.10     |   Wily Werewolf   | 2015-10-22 | 15.10   |   2015-10-22   | 2016-07-28 | 2016-07-28 |      False      |
| 15.04     |    Vivid Vervet   | 2015-04-23 | 15.04   |   2015-04-23   | 2016-02-04 | 2016-02-04 |      False      |
| 14.10     |   Utopic Unicorn  | 2014-10-23 | 14.10   |   2014-10-23   | 2015-07-23 | 2015-07-23 |      False      |
| 14.04 LTS |    Trusty Tahr    | 2014-04-17 | 14.04.6 |   2019-03-07   | 2019-04-02 | 2019-04-02 |    2024-04-02   |
| 12.04 LTS |  Precise Pangolin | 2012-04-26 | 12.04.5 |   2014-08-08   | 2017-04-28 | 2017-04-28 |    2019-04-26   |
```
```console
❯ eol ubuntu
┌───────────┬───────────────────┬────────────┬─────────┬────────────────┬────────────┬────────────┬─────────────────┐
│ cycle     │      codename     │  release   │ latest  │ latest release │  support   │    eol     │ extendedSupport │
├───────────┼───────────────────┼────────────┼─────────┼────────────────┼────────────┼────────────┼─────────────────┤
│ 23.04     │   Lunar Lobster   │ 2023-04-20 │ 23.04   │   2023-04-20   │ 2024-01-20 │ 2024-01-20 │      False      │
│ 22.10     │    Kinetic Kudu   │ 2022-10-20 │ 22.10   │   2022-10-20   │ 2023-07-20 │ 2023-07-20 │      False      │
│ 22.04 LTS │  Jammy Jellyfish  │ 2022-04-21 │ 22.04.2 │   2023-02-24   │ 2024-09-30 │ 2027-04-01 │    2032-04-09   │
│ 21.10     │    Impish Indri   │ 2021-10-14 │ 21.10   │   2021-10-14   │ 2022-07-14 │ 2022-07-14 │      False      │
│ 21.04     │   Hirsute Hippo   │ 2021-04-22 │ 21.04   │   2021-04-22   │ 2022-01-20 │ 2022-01-20 │      False      │
│ 20.10     │   Groovy Gorilla  │ 2020-10-22 │ 20.10   │   2020-10-22   │ 2021-07-22 │ 2021-07-22 │      False      │
│ 20.04 LTS │    Focal Fossa    │ 2020-04-23 │ 20.04.6 │   2023-03-23   │ 2022-10-01 │ 2025-04-02 │    2030-04-02   │
│ 19.10     │    Eoan Ermine    │ 2019-10-17 │ 19.10   │   2019-10-17   │ 2020-07-06 │ 2020-07-06 │      False      │
│ 19.04     │    Disco Dingo    │ 2019-04-18 │ 19.04   │   2019-04-18   │ 2020-01-23 │ 2020-01-23 │      False      │
│ 18.10     │ Cosmic Cuttlefish │ 2018-10-18 │ 18.10   │   2018-10-18   │ 2019-07-18 │ 2019-07-18 │      False      │
│ 18.04 LTS │   Bionic Beaver   │ 2018-04-26 │ 18.04.6 │   2021-09-17   │ 2023-05-31 │ 2023-05-31 │    2028-04-01   │
│ 17.10     │  Artful Aardvark  │ 2017-10-19 │ 17.10   │   2017-10-19   │ 2018-07-19 │ 2018-07-19 │      False      │
│ 17.04     │    Zesty Zapus    │ 2017-04-13 │ 17.04   │   2017-04-13   │ 2018-01-13 │ 2018-01-13 │      False      │
│ 16.04 LTS │    Xenial Xerus   │ 2016-04-21 │ 16.04.7 │   2020-08-13   │ 2021-04-02 │ 2021-04-02 │    2026-04-02   │
│ 15.10     │   Wily Werewolf   │ 2015-10-22 │ 15.10   │   2015-10-22   │ 2016-07-28 │ 2016-07-28 │      False      │
│ 15.04     │    Vivid Vervet   │ 2015-04-23 │ 15.04   │   2015-04-23   │ 2016-02-04 │ 2016-02-04 │      False      │
│ 14.10     │   Utopic Unicorn  │ 2014-10-23 │ 14.10   │   2014-10-23   │ 2015-07-23 │ 2015-07-23 │      False      │
│ 14.04 LTS │    Trusty Tahr    │ 2014-04-17 │ 14.04.6 │   2019-03-07   │ 2019-04-02 │ 2019-04-02 │    2024-04-02   │
│ 12.04 LTS │  Precise Pangolin │ 2012-04-26 │ 12.04.5 │   2014-08-08   │ 2017-04-28 │ 2017-04-28 │    2019-04-26   │
└───────────┴───────────────────┴────────────┴─────────┴────────────────┴────────────┴────────────┴─────────────────┘
```