### PR TITLE
Remove default 'cache-dependency-path: pyproject.toml'

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           python-version: "3.x"
           cache: pip
-          cache-dependency-path: pyproject.toml
+
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,7 +29,6 @@ jobs:
           python-version: "3.x"
           cache: pip
 
-
       - name: Install dependencies
         run: |
           python -m pip install -U pip

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
           allow-prereleases: true
           cache: pip
-          cache-dependency-path: pyproject.toml
+
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,6 @@ jobs:
           allow-prereleases: true
           cache: pip
 
-
       - name: Install dependencies
         run: |
           python -m pip install -U pip


### PR DESCRIPTION
Committed via https://github.com/asottile/all-repos