### PR TITLE
Replace 3rd-party thefuzz with stdlib `difflib.get_close_matches`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,6 @@ dependencies = [
   "python-dateutil",
   "python-slugify",
   "termcolor>=2.1",
-  "thefuzz",
 ]
 [project.optional-dependencies]
 tests = [

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,3 @@ pytest-cov==4.1.0
 python-slugify==8.0.1
 respx==0.20.1
 termcolor==2.3.0
-thefuzz==0.19.0

--- a/src/norwegianblue/__init__.py
+++ b/src/norwegianblue/__init__.py
@@ -96,17 +96,13 @@ def norwegianblue(
 
 @lru_cache(maxsize=None)
 def suggest_product(product: str) -> str:
-    import warnings
-
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore", category=UserWarning)
-        from thefuzz import process
+    import difflib
 
     # Get all known products from the API or cache
     all_products = norwegianblue("all").splitlines()
 
     # Find the closest match
-    result = process.extractOne(product, all_products)
+    result = difflib.get_close_matches(product, all_products, n=1)
     logging.info("Suggestion:\t%s (score: %d)", *result)
     return result[0]
 


### PR DESCRIPTION
I just heard about `difflib.get_close_matches` which is in the standard library, so we don't need to install the third-party [thefuzz](https://pypi.org/project/thefuzz/) for the "Did you mean?" suggestions.

https://docs.python.org/3/library/difflib.html#difflib.get_close_matches

```console
❯ eol pthon
Product 'pthon' not found, run 'eol all' for list. Did you mean: 'python'? [Y/n]
...

❯ eol hph
Product 'hph' not found, run 'eol all' for list. Did you mean: 'php'? [Y/n]
...

❯ eol androd
Product 'androd' not found, run 'eol all' for list. Did you mean: 'android'? [Y/n]
...

❯ eol samsung
Product 'samsung' not found, run 'eol all' for list. Did you mean: 'samsung-mobile'? [Y/n]
```

Follow on from https://github.com/hugovk/norwegianblue/pull/132 and https://github.com/hugovk/norwegianblue/pull/143.