### PR TITLE
Use hynek/build-and-inspect-python-package for releasing

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,2 +1,0 @@
-[flake8]
-max-line-length = 88

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,48 +2,74 @@ name: Deploy
 
 on:
   push:
-    branches:
-      - main
+    branches: [main]
+    tags: ["*"]
+  pull_request:
+    branches: [main]
   release:
     types:
       - published
   workflow_dispatch:
 
-jobs:
-  deploy:
-    if: github.repository_owner == 'hugovk'
-    runs-on: ubuntu-latest
+permissions:
+  contents: read
 
-    permissions:
-      # IMPORTANT: this permission is mandatory for trusted publishing
-      id-token: write
+jobs:
+  # Always build & lint package.
+  build-package:
+    name: Build & verify package
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - name: Set up Python
-        uses: actions/setup-python@v4
+      - uses: hynek/build-and-inspect-python-package@v1
+
+  # Upload to Test PyPI on every commit on main.
+  release-test-pypi:
+    name: Publish in-dev package to test.pypi.org
+    if: |
+      github.repository_owner == 'hugovk'
+      && github.event_name == 'push'
+      && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    needs: build-package
+
+    permissions:
+      id-token: write
+
+    steps:
+      - name: Download packages built by build-and-inspect-python-package
+        uses: actions/download-artifact@v3
         with:
-          python-version: "3.x"
-          cache: pip
+          name: Packages
+          path: dist
 
-      - name: Install dependencies
-        run: |
-          python -m pip install -U pip
-          python -m pip install -U build twine wheel
-
-      - name: Build package
-        run: |
-          python -m build
-          twine check --strict dist/*
-
-      - name: Publish package to PyPI
-        if: github.event.action == 'published'
-        uses: pypa/gh-action-pypi-publish@release/v1
-
-      - name: Publish package to TestPyPI
+      - name: Upload package to Test PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           repository-url: https://test.pypi.org/legacy/
+
+  # Upload to real PyPI on GitHub Releases.
+  release-pypi:
+    name: Publish released package to pypi.org
+    if: |
+      github.repository_owner == 'hugovk'
+      && github.event.action == 'published'
+    runs-on: ubuntu-latest
+    needs: build-package
+
+    permissions:
+      id-token: write
+
+    steps:
+      - name: Download packages built by build-and-inspect-python-package
+        uses: actions/download-artifact@v3
+        with:
+          name: Packages
+          path: dist
+
+      - name: Upload package to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -1,5 +1,8 @@
 name: Sync labels
 
+permissions:
+  pull-requests: write
+
 on:
   push:
     branches:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,6 +2,12 @@ name: Lint
 
 on: [push, pull_request, workflow_dispatch]
 
+env:
+  FORCE_COLOR: 1
+
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/require-pr-label.yml
+++ b/.github/workflows/require-pr-label.yml
@@ -8,6 +8,10 @@ jobs:
   label:
     runs-on: ubuntu-latest
 
+    permissions:
+      issues: write
+      pull-requests: write
+
     steps:
       - uses: mheap/github-action-required-labels@v5
         with:


### PR DESCRIPTION
Use https://github.com/hynek/build-and-inspect-python-package for releasing.

Add permissions to other workflows.

Remove `.flake8` config now we use Ruff.