### PR TITLE
Fix `KeyError` after 'Did you mean?' correction

### DIFF
--- a/src/norwegianblue/cli.py
+++ b/src/norwegianblue/cli.py
@@ -145,7 +145,7 @@ def main() -> None:
             suggestion = norwegianblue.suggest_product(product)
             output = norwegianblue.norwegianblue(
                 product=suggestion,
-                format=args.format,
+                format=args.formatter,
                 color=args.color,
                 show_title=multiple_products,
             )


### PR DESCRIPTION
# Before

```console
$ eol pytho
Product 'pytho' not found, run 'eol all' for list. Did you mean: 'python'? [Y/n] y
Traceback (most recent call last):
  File "/Users/hugo/github/norwegianblue/src/norwegianblue/cli.py", line 132, in main
    output = norwegianblue.norwegianblue(
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/hugo/github/norwegianblue/src/norwegianblue/__init__.py", line 66, in norwegianblue
    raise ValueError(msg)
ValueError: Product 'pytho' not found, run 'eol all' for list. Did you mean: 'python'?

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Library/Frameworks/Python.framework/Versions/3.11/bin/eol", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/Users/hugo/github/norwegianblue/src/norwegianblue/cli.py", line 146, in main
    output = norwegianblue.norwegianblue(
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/hugo/github/norwegianblue/src/norwegianblue/__init__.py", line 88, in norwegianblue
    output = _tabulate(data, format, color, product if show_title else None)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/hugo/github/norwegianblue/src/norwegianblue/__init__.py", line 210, in _tabulate
    return _pytablewriter(headers, data, format_, title)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/hugo/github/norwegianblue/src/norwegianblue/__init__.py", line 266, in _pytablewriter
    writer = format_writers[format_]()
             ~~~~~~~~~~~~~~^^^^^^^^^
KeyError: None
```

# After

```console
❯ eol pytho
Product 'pytho' not found, run 'eol all' for list. Did you mean: 'python'? [Y/n] y
┌───────┬────────────┬─────────┬────────────────┬────────────┬────────────┐
│ cycle │  release   │ latest  │ latest release │  support   │    eol     │
├───────┼────────────┼─────────┼────────────────┼────────────┼────────────┤
│ 3.12  │ 2023-10-02 │ 3.12.0  │   2023-10-02   │ 2025-04-02 │ 2028-10-02 │
│ 3.11  │ 2022-10-24 │ 3.11.6  │   2023-10-02   │ 2024-04-01 │ 2027-10-24 │
│ 3.10  │ 2021-10-04 │ 3.10.13 │   2023-08-24   │ 2023-04-05 │ 2026-10-04 │
│ 3.9   │ 2020-10-05 │ 3.9.18  │   2023-08-24   │ 2022-05-17 │ 2025-10-05 │
│ 3.8   │ 2019-10-14 │ 3.8.18  │   2023-08-24   │ 2021-05-03 │ 2024-10-14 │
│ 3.7   │ 2018-06-26 │ 3.7.17  │   2023-06-05   │ 2020-06-27 │ 2023-06-27 │
│ 3.6   │ 2016-12-22 │ 3.6.15  │   2021-09-03   │ 2018-12-24 │ 2021-12-23 │
│ 3.5   │ 2015-09-12 │ 3.5.10  │   2020-09-05   │   False    │ 2020-09-13 │
│ 3.4   │ 2014-03-15 │ 3.4.10  │   2019-03-18   │   False    │ 2019-03-18 │
│ 3.3   │ 2012-09-29 │ 3.3.7   │   2017-09-19   │   False    │ 2017-09-29 │
│ 2.7   │ 2010-07-03 │ 2.7.18  │   2020-04-19   │   False    │ 2020-01-01 │
│ 2.6   │ 2008-10-01 │ 2.6.9   │   2013-10-29   │   False    │ 2013-10-29 │
└───────┴────────────┴─────────┴────────────────┴────────────┴────────────┘
```

Caused by missing an `args.format` -> `args.formatter` rename in https://github.com/hugovk/norwegianblue/pull/169.