### PR TITLE
Fix IndexError when there are no suggestions

### DIFF
--- a/src/norwegianblue/__init__.py
+++ b/src/norwegianblue/__init__.py
@@ -22,7 +22,12 @@ __all__ = ["__version__"]
 
 BASE_URL = "https://endoflife.date/api/"
 USER_AGENT = f"norwegianblue/{__version__}"
-ERROR_404_TEXT = "Product '{}' not found, run 'eol all' for list. Did you mean: '{}'?"
+
+
+def error_404_text(product: str, suggestion: str) -> str:
+    return f"Product '{product}' not found, run 'eol all' for list." + (
+        f" Did you mean: '{suggestion}'?" if suggestion else ""
+    )
 
 
 def norwegianblue(
@@ -62,7 +67,7 @@ def norwegianblue(
         logging.info("HTTP status code: %d", r.status_code)
         if r.status_code == 404:
             suggestion = suggest_product(product)
-            msg = ERROR_404_TEXT.format(product, suggestion)
+            msg = error_404_text(product, suggestion)
             raise ValueError(msg)
 
         # Raise if we made a bad request
@@ -104,7 +109,7 @@ def suggest_product(product: str) -> str:
     # Find the closest match
     result = difflib.get_close_matches(product, all_products, n=1)
     logging.info("Suggestion:\t%s (score: %d)", *result)
-    return result[0]
+    return result[0] if result else ""
 
 
 def _ltsify(data: list[dict]) -> list[dict]:

--- a/src/norwegianblue/cli.py
+++ b/src/norwegianblue/cli.py
@@ -143,10 +143,12 @@ def main() -> None:
                 prompt = colored(prompt, "yellow")
             if not suggestion:
                 print(prompt)
-                sys.exit()
+                print()
+                continue
             answer = input(prompt)
             if answer not in ("", "y", "Y"):
-                sys.exit()
+                print()
+                continue
             output = norwegianblue.norwegianblue(
                 product=suggestion,
                 format=args.formatter,

--- a/src/norwegianblue/cli.py
+++ b/src/norwegianblue/cli.py
@@ -136,13 +136,17 @@ def main() -> None:
                 show_title=multiple_products,
             )
         except ValueError as e:
-            prompt = f"{e} [Y/n] "
+            suggestion = norwegianblue.suggest_product(product)
+
+            prompt = f"{e}{' [Y/n] ' if suggestion else ''}"
             if args.color != "no":
                 prompt = colored(prompt, "yellow")
+            if not suggestion:
+                print(prompt)
+                sys.exit()
             answer = input(prompt)
             if answer not in ("", "y", "Y"):
                 sys.exit()
-            suggestion = norwegianblue.suggest_product(product)
             output = norwegianblue.norwegianblue(
                 product=suggestion,
                 format=args.formatter,

--- a/tests/test_norwegianblue.py
+++ b/tests/test_norwegianblue.py
@@ -389,9 +389,20 @@ class TestNorwegianBlue:
         assert output == expected
 
     @respx.mock
-    def test_404(self) -> None:
+    @pytest.mark.parametrize(
+        "product, expected",
+        [
+            (
+                "androd",
+                r"Product 'androd' not found, run 'eol all' for list\. "
+                r"Did you mean: 'android'?",
+            ),
+            ("julia", r"Product 'julia' not found, run 'eol all' for list\."),
+        ],
+    )
+    def test_404(self, product, expected) -> None:
         # Arrange
-        mocked_url = "https://endoflife.date/api/androd.json"
+        mocked_url = f"https://endoflife.date/api/{product}.json"
         respx.get(mocked_url).respond(status_code=404)
 
         mocked_url = "https://endoflife.date/api/all.json"
@@ -399,29 +410,8 @@ class TestNorwegianBlue:
         respx.get(mocked_url).respond(content=mocked_response)
 
         # Act / Assert
-        with pytest.raises(
-            ValueError,
-            match=r"Product 'androd' not found, run 'eol all' for list\. "
-            r"Did you mean: 'android'?",
-        ):
-            norwegianblue.norwegianblue(product="androd")
-
-    @respx.mock
-    def test_404_no_suggestions(self) -> None:
-        # Arrange
-        mocked_url = "https://endoflife.date/api/julia.json"
-        respx.get(mocked_url).respond(status_code=404)
-
-        mocked_url = "https://endoflife.date/api/all.json"
-        mocked_response = SAMPLE_RESPONSE_ALL_JSON
-        respx.get(mocked_url).respond(content=mocked_response)
-
-        # Act / Assert
-        with pytest.raises(
-            ValueError,
-            match=r"Product 'julia' not found, run 'eol all' for list\.",
-        ):
-            norwegianblue.norwegianblue(product="julia")
+        with pytest.raises(ValueError, match=expected):
+            norwegianblue.norwegianblue(product=product)
 
     def test_norwegianblue_norwegianblue(self) -> None:
         # Act

--- a/tests/test_norwegianblue.py
+++ b/tests/test_norwegianblue.py
@@ -406,6 +406,23 @@ class TestNorwegianBlue:
         ):
             norwegianblue.norwegianblue(product="androd")
 
+    @respx.mock
+    def test_404_no_suggestions(self) -> None:
+        # Arrange
+        mocked_url = "https://endoflife.date/api/julia.json"
+        respx.get(mocked_url).respond(status_code=404)
+
+        mocked_url = "https://endoflife.date/api/all.json"
+        mocked_response = SAMPLE_RESPONSE_ALL_JSON
+        respx.get(mocked_url).respond(content=mocked_response)
+
+        # Act / Assert
+        with pytest.raises(
+            ValueError,
+            match=r"Product 'julia' not found, run 'eol all' for list\.",
+        ):
+            norwegianblue.norwegianblue(product="julia")
+
     def test_norwegianblue_norwegianblue(self) -> None:
         # Act
         output = norwegianblue.norwegianblue(product="norwegianblue")


### PR DESCRIPTION

When there are no suggestions returned by **suggest_product()** we get an IndexError from attempting to read the first element of an empty list.

I changed it such that if there are no suggestions, no [Y/n] option will be given; the prompt will only state that the search term is not found and exit immediately.
 
#### Before

```bash
$ eol julia
Traceback (most recent call last):
  File "/home/tingfeng/miniconda3/bin/eol", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/home/tingfeng/miniconda3/lib/python3.11/site-packages/norwegianblue/cli.py", line 132, in main
    output = norwegianblue.norwegianblue(
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/tingfeng/miniconda3/lib/python3.11/site-packages/norwegianblue/__init__.py", line 64, in norwegianblue
    suggestion = suggest_product(product)
                 ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/tingfeng/miniconda3/lib/python3.11/site-packages/norwegianblue/__init__.py", line 107, in suggest_product
    return result[0]
           ~~~~~~^^^
IndexError: list index out of range
$
```

#### After

```bash
$ eol julia
Product 'julia' not found, run 'eol all' for list.
$
```