### PR TITLE
Disable colour to fix CI

### DIFF
--- a/tests/test_norwegianblue.py
+++ b/tests/test_norwegianblue.py
@@ -64,6 +64,7 @@ class TestNorwegianBlue:
         _cache.filename = self.original__cache_filename
         _cache.save = self.original__save_cache
 
+    @mock.patch.dict(os.environ, {"NO_COLOR": "TRUE"})
     @respx.mock
     @pytest.mark.parametrize(
         "test_format, test_show_title, expected",
@@ -98,6 +99,7 @@ class TestNorwegianBlue:
         # Assert
         assert output.strip() == expected.strip()
 
+    @mock.patch.dict(os.environ, {"NO_COLOR": "TRUE"})
     @respx.mock
     @pytest.mark.parametrize(
         "test_product, sample_response, expected",


### PR DESCRIPTION
The CI started failing like this:

<img width="753" alt="image" src="https://github.com/hugovk/norwegianblue/assets/1324225/78428026-2fc4-42b9-a349-a8ee925c2b50">

Because the `FORCE_COLOR=1` from the workflow is being passed to the tests, and adding colour to the output. 

Let's instead disable colour for the affected tests by setting `NO_COLOR` to `True`, like we do with another, because colour isn't relevant to these tests.