### PR TITLE
Add --show-title flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ options:
   -c {yes,no,auto}, --color {yes,no,auto}
                         colour the output (default: auto)
   --clear-cache         clear cache before running
+  --show-title {yes,no,auto}
+                        show or hide product title, 'auto' to show title only for multiple products (default: auto)
   -v, --verbose         print extra messages to stderr
   -V, --version         show program's version number and exit
   -w, --web             open product page in web browser

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ run("eol --help")
 
 ```console
 $ eol --help
-usage: eol [-h] [-f {html,json,md,markdown,pretty,rst,csv,tsv,yaml}] [-c {yes,no,auto}] [--clear-cache] [-v] [-V] [-w]
+usage: eol [-h] [-f {html,json,md,markdown,pretty,rst,csv,tsv,yaml}] [-c {yes,no,auto}] [--clear-cache] [--show-title {yes,no,auto}] [-v] [-V] [-w]
            [--pretty | --md | --rst | --json | --csv | --tsv | --html | --yaml]
            [product ...]
 

--- a/src/norwegianblue/__init__.py
+++ b/src/norwegianblue/__init__.py
@@ -2,6 +2,7 @@
 Python interface to endoflife.date API
 https://endoflife.date/docs/api/
 """
+
 from __future__ import annotations
 
 import datetime as dt

--- a/src/norwegianblue/_cache.py
+++ b/src/norwegianblue/_cache.py
@@ -1,6 +1,7 @@
 """
 Cache functions
 """
+
 from __future__ import annotations
 
 import datetime as dt

--- a/src/norwegianblue/cli.py
+++ b/src/norwegianblue/cli.py
@@ -68,6 +68,12 @@ def main() -> None:
         "--clear-cache", action="store_true", help="clear cache before running"
     )
     parser.add_argument(
+        "--show-title",
+        default="auto",
+        choices=("yes", "no", "auto"),
+        help="show or hide product title, 'auto' to show title only for multiple products (default: auto)",
+    )
+    parser.add_argument(
         "-v",
         "--verbose",
         action="store_const",
@@ -133,7 +139,8 @@ def main() -> None:
                 product=product,
                 format=args.formatter,
                 color=args.color,
-                show_title=multiple_products,
+                show_title=(args.show_title == "yes")
+                or (multiple_products and args.show_title != "no"),
             )
         except ValueError as e:
             suggestion = norwegianblue.suggest_product(product)

--- a/src/norwegianblue/cli.py
+++ b/src/norwegianblue/cli.py
@@ -71,7 +71,8 @@ def main() -> None:
         "--show-title",
         default="auto",
         choices=("yes", "no", "auto"),
-        help="show or hide product title, 'auto' to show title only for multiple products (default: auto)",
+        help="show or hide product title, 'auto' to show title "
+        "only for multiple products (default: auto)",
     )
     parser.add_argument(
         "-v",

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,6 +1,7 @@
 """
 Unit tests for norwegianblue cache
 """
+
 from __future__ import annotations
 
 import tempfile

--- a/tests/test_norwegianblue.py
+++ b/tests/test_norwegianblue.py
@@ -1,6 +1,7 @@
 """
 Unit tests for norwegianblue
 """
+
 from __future__ import annotations
 
 import json


### PR DESCRIPTION
Closes #192

Default behavior remains unchanged; Single product -> No title, Multiple products -> Show title for each product

If `--show-title` is `yes`, title is always shown. When `no`, title is never shown.