### PR TITLE
Use `args.show_title` after accepting suggestion

### DIFF
--- a/src/norwegianblue/cli.py
+++ b/src/norwegianblue/cli.py
@@ -134,14 +134,14 @@ def main() -> None:
         _cache.clear(clear_all=True)
 
     multiple_products = len(args.product) >= 2
+    show_title = (args.show_title == "yes") or (multiple_products and args.show_title != "no")
     for product in args.product:
         try:
             output = norwegianblue.norwegianblue(
                 product=product,
                 format=args.formatter,
                 color=args.color,
-                show_title=(args.show_title == "yes")
-                or (multiple_products and args.show_title != "no"),
+                show_title=show_title,
             )
         except ValueError as e:
             suggestion = norwegianblue.suggest_product(product)
@@ -161,8 +161,7 @@ def main() -> None:
                 product=suggestion,
                 format=args.formatter,
                 color=args.color,
-                show_title=(args.show_title == "yes")
-                or (multiple_products and args.show_title != "no"),
+                show_title=show_title,
             )
         print(output)
         print()

--- a/src/norwegianblue/cli.py
+++ b/src/norwegianblue/cli.py
@@ -134,7 +134,9 @@ def main() -> None:
         _cache.clear(clear_all=True)
 
     multiple_products = len(args.product) >= 2
-    show_title = (args.show_title == "yes") or (multiple_products and args.show_title != "no")
+    show_title = (args.show_title == "yes") or (
+        multiple_products and args.show_title != "no"
+    )
     for product in args.product:
         try:
             output = norwegianblue.norwegianblue(

--- a/src/norwegianblue/cli.py
+++ b/src/norwegianblue/cli.py
@@ -161,7 +161,8 @@ def main() -> None:
                 product=suggestion,
                 format=args.formatter,
                 color=args.color,
-                show_title=multiple_products,
+                show_title=(args.show_title == "yes")
+                or (multiple_products and args.show_title != "no"),
             )
         print(output)
         print()


### PR DESCRIPTION
Bugfix for **args.show_title** not being used after accepting a `Did you mean [Y/n]` suggestion.