### PR TITLE
Autocomplete after the eol command

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ dependencies = [
   "python-dateutil",
   "python-slugify",
   "termcolor>=2.1",
+  "argcomplete>=3.4"
 ]
 optional-dependencies.tests = [
   "freezegun",

--- a/src/norwegianblue/__init__.py
+++ b/src/norwegianblue/__init__.py
@@ -99,19 +99,19 @@ def norwegianblue(
 
     return output
 
+def all_products() -> list[str]:
+    """Get all known products from the API or cache"""
+    return norwegianblue("all").splitlines()
 
 @lru_cache(maxsize=None)
 def suggest_product(product: str) -> str:
+    """Provide the best suggestion based on a typed product"""
     import difflib
 
-    # Get all known products from the API or cache
-    all_products = norwegianblue("all").splitlines()
-
     # Find the closest match
-    result = difflib.get_close_matches(product, all_products, n=1)
+    result = difflib.get_close_matches(product, all_products(), n=1)
     logging.info("Suggestion:\t%s (score: %d)", *result)
     return result[0] if result else ""
-
 
 def _ltsify(data: list[dict]) -> list[dict]:
     """If a cycle is LTS, append LTS to the cycle version and remove the LTS column"""

--- a/src/norwegianblue/cli.py
+++ b/src/norwegianblue/cli.py
@@ -14,6 +14,7 @@ Something missing? Please contribute! https://endoflife.date/contribute
 from __future__ import annotations
 
 import argparse
+import argcomplete
 import atexit
 import logging
 import platform
@@ -26,6 +27,9 @@ from norwegianblue import _cache
 
 atexit.register(_cache.clear)
 
+def ProductCompleter(**kwargs):
+    """The list of all products to feed autocompletion"""
+    return norwegianblue.all_products()
 
 def main() -> None:
     parser = argparse.ArgumentParser(
@@ -36,7 +40,7 @@ def main() -> None:
         nargs="*",
         default=["all"],
         help="product to check, or 'all' to list all available (default: 'all')",
-    )
+    ).completer =  ProductCompleter
     parser.add_argument(
         "-f",
         "--format",
@@ -115,7 +119,7 @@ def main() -> None:
             help=f"output in {help_text}",
         )
     parser.set_defaults(formatter="pretty")
-
+    argcomplete.autocomplete(parser)
     args = parser.parse_args()
 
     if args.format:


### PR DESCRIPTION
Hello,

This is a draft to resolve #125.
As the project is using [argparse](http://docs.python.org/3/library/argparse.html), I thought it was a good idea to use [argcomplete](https://github.com/kislyuk/argcomplete).
This implementation is very simple but it seems to do the trick.

```bash
# register eol with the shell's completion framework by running register-python-argcomplete:
eval "$(register-python-argcomplete my-python-app)"
# use it
eol ne
nextcloud  nextjs  netbsd  nexus  neo4j  neos  --    
```
Cheers 🍰 