### PR TITLE
Generate `__version__` at build to avoid slow `importlib.metadata` import

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,3 +110,6 @@ venv.bak/
 .mypy_cache/
 .dmypy.json
 dmypy.json
+
+# hatch-vcs
+src/norwegianblue/_version.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,9 @@ norwegianblue = "norwegianblue.cli:main"
 [tool.hatch]
 version.source = "vcs"
 
+[tool.hatch.build.hooks.vcs]
+version-file = "src/norwegianblue/_version.py"
+
 [tool.hatch.version.raw-options]
 local_scheme = "no-local-version"
 

--- a/src/norwegianblue/__init__.py
+++ b/src/norwegianblue/__init__.py
@@ -6,7 +6,6 @@ https://endoflife.date/docs/api/
 from __future__ import annotations
 
 import datetime as dt
-import importlib.metadata
 import json
 import logging
 from functools import lru_cache
@@ -14,15 +13,13 @@ from functools import lru_cache
 from dateutil.relativedelta import relativedelta
 from termcolor import colored
 
-from norwegianblue import _cache
+from norwegianblue import _cache, _version
 
-__version__ = importlib.metadata.version(__name__)
-
+__version__ = _version.__version__
 
 __all__ = ["__version__"]
 
 BASE_URL = "https://endoflife.date/api/"
-USER_AGENT = f"norwegianblue/{__version__}"
 
 
 def error_404_text(product: str, suggestion: str) -> str:
@@ -63,7 +60,11 @@ def norwegianblue(
         # No cache, or couldn't load cache
         import httpx
 
-        r = httpx.get(url, follow_redirects=True, headers={"User-Agent": USER_AGENT})
+        r = httpx.get(
+            url,
+            follow_redirects=True,
+            headers={"User-Agent": f"norwegianblue/{__version__}"},
+        )
 
         logging.info("HTTP status code: %d", r.status_code)
         if r.status_code == 404:


### PR DESCRIPTION
With Python 3.12.4:

```sh
python -X importtime -c "import norwegianblue" 2> import.log && tuna import.log
```

Cuts out the 22ms `importlib.metadata` import.

# `main`

<img width="1624" alt="image" src="https://github.com/user-attachments/assets/494b7348-633f-4b17-9cc0-34c7d609b9c4">

```console
❯ hyperfine -w 8 "eol --version"
Benchmark 1: eol --version
  Time (mean ± σ):      55.1 ms ±   3.8 ms    [User: 43.3 ms, System: 10.4 ms]
  Range (min … max):    50.9 ms …  71.4 ms    53 runs
```

# PR

<img width="1624" alt="image" src="https://github.com/user-attachments/assets/fddd61d3-3d58-491d-8ad4-8d19525201d5">

```console
❯ hyperfine -w 8 "eol --version"
Benchmark 1: eol --version
  Time (mean ± σ):      38.2 ms ±   1.7 ms    [User: 29.6 ms, System: 7.3 ms]
  Range (min … max):    35.3 ms …  41.9 ms    73 runs
```

