### PR TITLE
Use pre-commit-uv for lint

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,7 +4,6 @@ on: [push, pull_request, workflow_dispatch]
 
 env:
   FORCE_COLOR: 1
-  PIP_DISABLE_PIP_VERSION_CHECK: 1
 
 permissions:
   contents: read
@@ -15,8 +14,4 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.x"
-          cache: pip
-      - uses: pre-commit/action@v3.0.1
+      - uses: hugovk/pre-commit-action-uv@v3.0.1


### PR DESCRIPTION
# Before

No Actions cache: 1m 5s

https://github.com/hugovk/norwegianblue/actions/runs/11332579656/job/31514988544

With Actions cache: 19s

https://github.com/hugovk/norwegianblue/actions/runs/11332596790/job/31515040851

# After

No Actions cache: 44s

https://github.com/hugovk/norwegianblue/actions/runs/11332607215/job/31515072047

With Actions cache: 13s

https://github.com/hugovk/norwegianblue/actions/runs/11332620769/job/31515116728
