### PR TITLE
Replace deprecated constants with enums

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dynamic = [ "version" ]
 dependencies = [
   "httpx>=0.19",
   "platformdirs",
-  "prettytable>=2.4",
+  "prettytable>=3.12",
   "pytablewriter[html]>=0.63",
   "python-dateutil",
   "python-slugify",

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 freezegun==1.5.1
 httpx==0.27.2
 platformdirs==4.3.6
-prettytable==3.11.0
+prettytable==3.12.0
 pytablewriter[html]==1.2.0
 pytest==8.3.3
 pytest-cov==5.0.0

--- a/src/norwegianblue/__init__.py
+++ b/src/norwegianblue/__init__.py
@@ -229,8 +229,8 @@ def _prettytable(
 ) -> str:
     from prettytable import PrettyTable, TableStyle
 
-    x = PrettyTable()
-    x.set_style(
+    table = PrettyTable()
+    table.set_style(
         TableStyle.MARKDOWN if format_ == "markdown" else TableStyle.SINGLE_BORDER
     )
     do_color = color != "no" and format_ == "pretty"
@@ -239,19 +239,19 @@ def _prettytable(
         left_align = header in ("cycle", "latest", "link")
         display_header = colored(header, attrs=["bold"]) if do_color else header
         col_data = [row[header] if header in row else "" for row in data]
-        x.add_column(display_header, col_data)
+        table.add_column(display_header, col_data)
 
         if left_align:
-            x.align[display_header] = "l"
+            table.align[display_header] = "l"
 
     title_prefix = ""
     if title:
         if format_ == "pretty":
-            x.title = colored(title, attrs=["bold"]) if do_color else title
+            table.title = colored(title, attrs=["bold"]) if do_color else title
         else:
             title_prefix = f"## {title}\n\n"
 
-    return title_prefix + x.get_string()
+    return title_prefix + table.get_string()
 
 
 def _pytablewriter(

--- a/src/norwegianblue/__init__.py
+++ b/src/norwegianblue/__init__.py
@@ -227,10 +227,12 @@ def _prettytable(
     color: str = "yes",
     title: str | None = None,
 ) -> str:
-    from prettytable import MARKDOWN, SINGLE_BORDER, PrettyTable
+    from prettytable import PrettyTable, TableStyle
 
     x = PrettyTable()
-    x.set_style(MARKDOWN if format_ == "markdown" else SINGLE_BORDER)
+    x.set_style(
+        TableStyle.MARKDOWN if format_ == "markdown" else TableStyle.SINGLE_BORDER
+    )
     do_color = color != "no" and format_ == "pretty"
 
     for header in headers:


### PR DESCRIPTION
https://github.com/prettytable/prettytable/releases/tag/3.12.0
https://github.com/prettytable/prettytable/pull/329

Fixes:
```python
tests/test_norwegianblue.py::TestNorwegianBlue::test_norwegianblue_formats[markdown0]
  /Users/hugo/github/norwegianblue/src/norwegianblue/__init__.py:230: DeprecationWarning: the 'MARKDOWN' constant is deprecated, use the 'TableStyle' enum instead
    from prettytable import MARKDOWN, SINGLE_BORDER, PrettyTable

tests/test_norwegianblue.py::TestNorwegianBlue::test_norwegianblue_formats[markdown0]
  /Users/hugo/github/norwegianblue/src/norwegianblue/__init__.py:230: DeprecationWarning: the 'SINGLE_BORDER' constant is deprecated, use the 'TableStyle' enum instead
    from prettytable import MARKDOWN, SINGLE_BORDER, PrettyTable
```
