### PR TITLE
Use `format=None` to return raw Python data structure

### DIFF
--- a/src/norwegianblue/__init__.py
+++ b/src/norwegianblue/__init__.py
@@ -30,10 +30,10 @@ def error_404_text(product: str, suggestion: str) -> str:
 
 def norwegianblue(
     product: str = "all",
-    format: str = "pretty",
+    format: str | None = "pretty",
     color: str = "yes",
     show_title: bool = False,
-) -> str:
+) -> str | list[dict]:
     """Call the API and return result"""
     if format == "md":
         format = "markdown"
@@ -84,6 +84,9 @@ def norwegianblue(
         return json.dumps(res)
 
     data: list[dict] = list(res)
+
+    if format is None:
+        return data
 
     if product == "all":
         return "\n".join(data)

--- a/tests/test_norwegianblue.py
+++ b/tests/test_norwegianblue.py
@@ -103,6 +103,30 @@ class TestNorwegianBlue:
         # Assert
         assert output.strip() == expected.strip()
 
+    @freeze_time("2023-11-23")
+    @respx.mock
+    def test_norwegianblue_no_format(self) -> None:
+        # Arrange
+        mocked_url = "https://endoflife.date/api/ubuntu.json"
+        mocked_response = SAMPLE_RESPONSE_JSON_UBUNTU
+        test_format = None
+
+        # Act
+        respx.get(mocked_url).respond(content=mocked_response)
+        output = norwegianblue.norwegianblue(product="ubuntu", format=test_format)
+
+        # Assert
+        assert output[0] == {
+            "cycle": "22.04",
+            "codename": "Jammy Jellyfish",
+            "support": "2027-04-02",
+            "eol": "2032-04-01",
+            "lts": True,
+            "latest": "22.04",
+            "link": "https://wiki.ubuntu.com/JammyJellyfish/ReleaseNotes/",
+            "releaseDate": "2022-04-21",
+        }
+
     @mock.patch.dict(os.environ, {"NO_COLOR": "TRUE"})
     @respx.mock
     @pytest.mark.parametrize(


### PR DESCRIPTION
Fixes https://github.com/hugovk/norwegianblue/issues/228.

For programmatic use, return the decoded JSON before turning it into a formatted string.

So there's no need to do something like parse a JSON string back into a Python data structure.
