### PR TITLE
Suggest the correct choice when invalid (Python 3.14+)

### DIFF
--- a/src/norwegianblue/cli.py
+++ b/src/norwegianblue/cli.py
@@ -29,7 +29,8 @@ atexit.register(_cache.clear)
 
 def main() -> None:
     parser = argparse.ArgumentParser(
-        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter,
+        suggest_on_error=True,
     )
     parser.add_argument(
         "product",

--- a/src/norwegianblue/cli.py
+++ b/src/norwegianblue/cli.py
@@ -29,9 +29,10 @@ atexit.register(_cache.clear)
 
 def main() -> None:
     parser = argparse.ArgumentParser(
-        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter,
-        suggest_on_error=True,
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
     )
+    # Added in Python 3.14
+    parser.suggest_on_error = True
     parser.add_argument(
         "product",
         nargs="*",


### PR DESCRIPTION
# Before

```console
❯ python3.14 -m norwegianblue python --color ye
usage: python3.14 -m norwegianblue [-h] [-f {html,json,md,markdown,pretty,rst,csv,tsv,yaml}] [-c {yes,no,auto}] [--clear-cache] [--show-title {yes,no,auto}] [-v]
                                   [-V] [-w] [--pretty | --md | --rst | --json | --csv | --tsv | --html | --yaml]
                                   [product ...]
python3.14 -m norwegianblue: error: argument -c/--color: invalid choice: 'ye' (choose from yes, no, auto)
```

# After

```console
❯ python3.14 -m norwegianblue python --color ye
usage: python3.14 -m norwegianblue [-h] [-f {html,json,md,markdown,pretty,rst,csv,tsv,yaml}] [-c {yes,no,auto}] [--clear-cache] [--show-title {yes,no,auto}] [-v]
                                   [-V] [-w] [--pretty | --md | --rst | --json | --csv | --tsv | --html | --yaml]
                                   [product ...]
python3.14 -m norwegianblue: error: argument -c/--color: invalid choice: 'ye', maybe you meant 'yes'? (choose from yes, no, auto)
```

# Backwards compatibility


This was added in Python 3.14:

https://docs.python.org/3.14/library/argparse.html#suggest-on-error

So we can't do this:


```diff
 def main() -> None:
     parser = argparse.ArgumentParser(
-        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter, suggest_on_error=True
     )
```
Because we'll get an error on 3.13 and earlier:
```pytb
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/Users/hugo/github/norwegianblue/src/norwegianblue/__main__.py", line 6, in <module>
    cli.main()
    ~~~~~~~~^^
  File "/Users/hugo/github/norwegianblue/src/norwegianblue/cli.py", line 31, in main
    parser = argparse.ArgumentParser(
        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter, suggest_on_error=True
    )
TypeError: ArgumentParser.__init__() got an unexpected keyword argument 'suggest_on_error'
```
Instead, `parser.suggest_on_error = True` enables it on 3.14+ and prevents the error for 3.13 and older.
