### PR TITLE
Only create PyPI digital attestations (PEP 740)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,8 +11,7 @@ on:
       - published
   workflow_dispatch:
 
-permissions:
-  contents: read
+permissions: {}
 
 env:
   FORCE_COLOR: 1
@@ -35,7 +34,7 @@ jobs:
   release-test-pypi:
     name: Publish in-dev package to test.pypi.org
     if: |
-      github.repository_owner == 'hugovk'
+      github.event.repository.fork == false
       && github.event_name == 'push'
       && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
@@ -54,14 +53,13 @@ jobs:
       - name: Upload package to Test PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          attestations: true
           repository-url: https://test.pypi.org/legacy/
 
   # Upload to real PyPI on GitHub Releases.
   release-pypi:
     name: Publish released package to pypi.org
     if: |
-      github.repository_owner == 'hugovk'
+      github.event.repository.fork == false
       && github.event.action == 'published'
     runs-on: ubuntu-latest
     needs: build-package
@@ -78,5 +76,3 @@ jobs:
 
       - name: Upload package to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          attestations: true

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,7 +42,6 @@ jobs:
     needs: build-package
 
     permissions:
-      attestations: write
       id-token: write
 
     steps:
@@ -51,11 +50,6 @@ jobs:
         with:
           name: Packages
           path: dist
-
-      - name: Attest build provenance
-        uses: actions/attest-build-provenance@v2
-        with:
-          subject-path: "dist/*"
 
       - name: Upload package to Test PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
@@ -73,7 +67,6 @@ jobs:
     needs: build-package
 
     permissions:
-      attestations: write
       id-token: write
 
     steps:
@@ -82,11 +75,6 @@ jobs:
         with:
           name: Packages
           path: dist
-
-      - name: Attest build provenance
-        uses: actions/attest-build-provenance@v2
-        with:
-          subject-path: "dist/*"
 
       - name: Upload package to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,11 +2,11 @@ name: Lint
 
 on: [push, pull_request, workflow_dispatch]
 
+permissions: {}
+
 env:
   FORCE_COLOR: 1
-
-permissions:
-  contents: read
+  RUFF_OUTPUT_FORMAT: github
 
 jobs:
   lint:

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -14,12 +14,9 @@ on:
   #   types: [opened, reopened, synchronize]
   workflow_dispatch:
 
-permissions:
-  contents: read
-
 jobs:
   update_release_draft:
-    if: github.repository_owner == 'hugovk'
+    if: github.event.repository.fork == false
     permissions:
       # write permission is required to create a GitHub Release
       contents: write

--- a/.github/workflows/require-pr-label.yml
+++ b/.github/workflows/require-pr-label.yml
@@ -17,6 +17,11 @@ jobs:
         with:
           mode: minimum
           count: 1
-          labels:
-            "changelog: Added, changelog: Changed, changelog: Deprecated, changelog:
-            Fixed, changelog: Removed, changelog: Security, changelog: skip"
+          labels: |
+            changelog: Added
+            changelog: Changed
+            changelog: Deprecated
+            changelog: Fixed
+            changelog: Removed
+            changelog: Security
+            changelog: skip

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["pypy3.10", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["pypy3.11", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
         os: [windows-latest, macos-latest, ubuntu-latest]
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,8 +2,7 @@ name: Test
 
 on: [push, pull_request, workflow_dispatch]
 
-permissions:
-  contents: read
+permissions: {}
 
 env:
   FORCE_COLOR: 1
@@ -29,7 +28,7 @@ jobs:
           allow-prereleases: true
 
       - name: Install uv
-        uses: hynek/setup-cached-uv@v2
+        uses: astral-sh/setup-uv@v5
 
       - name: Tox tests
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,6 +38,11 @@ repos:
     hooks:
       - id: actionlint
 
+  - repo: https://github.com/woodruffw/zizmor-pre-commit
+    rev: v1.4.1
+    hooks:
+      - id: zizmor
+
   #  - repo: https://github.com/pre-commit/mirrors-mypy
   #    rev: v1.7.0
   #    hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -71,11 +71,17 @@ repos:
     hooks:
       - id: tox-ini-fmt
 
+  - repo: https://github.com/google/yamlfmt
+    rev: v0.16.0
+    hooks:
+      - id: yamlfmt
+
   - repo: https://github.com/rbubley/mirrors-prettier
     rev: v3.5.2
     hooks:
       - id: prettier
         args: [--prose-wrap=always, --print-width=88]
+        exclude_types: [yaml]
 
   - repo: meta
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,12 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.8.6
+    rev: v0.9.9
     hooks:
       - id: ruff
         args: [--exit-non-zero-on-fix]
 
   - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 24.10.0
+    rev: 25.1.0
     hooks:
       - id: black
 
@@ -16,6 +16,7 @@ repos:
       - id: check-added-large-files
       - id: check-case-conflict
       - id: check-merge-conflict
+      - id: check-shebang-scripts-are-executable
       - id: check-json
       - id: check-toml
       - id: check-yaml
@@ -27,13 +28,13 @@ repos:
         exclude: tests/data/expected_output.py
 
   - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: 0.30.0
+    rev: 0.31.2
     hooks:
       - id: check-github-workflows
       - id: check-renovate
 
   - repo: https://github.com/rhysd/actionlint
-    rev: v1.7.6
+    rev: v1.7.7
     hooks:
       - id: actionlint
 
@@ -66,12 +67,12 @@ repos:
       - id: validate-pyproject
 
   - repo: https://github.com/tox-dev/tox-ini-fmt
-    rev: 1.4.1
+    rev: 1.5.0
     hooks:
       - id: tox-ini-fmt
 
   - repo: https://github.com/rbubley/mirrors-prettier
-    rev: v3.4.2
+    rev: v3.5.2
     hooks:
       - id: prettier
         args: [--prose-wrap=always, --print-width=88]

--- a/.yamlfmt.yaml
+++ b/.yamlfmt.yaml
@@ -1,0 +1,2 @@
+formatter:
+  retain_line_breaks_single: true

--- a/src/norwegianblue/cli.py
+++ b/src/norwegianblue/cli.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """
 CLI to show end-of-life dates for a number of products, from https://endoflife.date
 
@@ -11,6 +10,7 @@ For example:
 
 Something missing? Please contribute! https://endoflife.date/contribute
 """
+
 from __future__ import annotations
 
 import argparse


### PR DESCRIPTION
Generating PyPI's digital attestations should be enough (https://docs.pypi.org/attestations/), we don't _also_ need to use https://github.com/actions/attest-build-provenance.

Also test PyPy3.11 and update linting/config.