### PR TITLE
Clear termcolor cache after each test

### DIFF
--- a/tests/test_norwegianblue.py
+++ b/tests/test_norwegianblue.py
@@ -13,6 +13,7 @@ from unittest import mock
 import pytest
 import respx
 from freezegun import freeze_time
+from termcolor import termcolor
 
 import norwegianblue
 from norwegianblue import _cache
@@ -66,6 +67,11 @@ class TestNorwegianBlue:
         # Unstub caching
         _cache.filename = self.original__cache_filename
         _cache.save = self.original__save_cache
+        try:
+            # termcolor 3.1+
+            termcolor._can_do_colour.cache_clear()
+        except AttributeError:
+            pass
 
     @freeze_time("2023-11-23")
     @mock.patch.dict(os.environ, {"NO_COLOR": "TRUE"})


### PR DESCRIPTION
Needed for a clean slate between tests after https://github.com/termcolor/termcolor/pull/107.

To fix https://github.com/hugovk/norwegianblue/pull/248 and https://github.com/hugovk/norwegianblue/pull/249.