### PR TITLE
Enable colour help for Python 3.14

### DIFF
--- a/src/norwegianblue/cli.py
+++ b/src/norwegianblue/cli.py
@@ -31,7 +31,8 @@ def main() -> None:
     parser = argparse.ArgumentParser(
         description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
     )
-    # Added in Python 3.14
+    # Both added in Python 3.14
+    parser.color = "yes"
     parser.suggest_on_error = True
     parser.add_argument(
         "product",


### PR DESCRIPTION
Will be available for 3.14 beta:

https://docs.python.org/3.14/library/argparse.html#color

<table>
<tr>
<th>Before
<th>After
<tr>
<td>
<img width="801" alt="image" src="https://github.com/user-attachments/assets/38775c4b-29d3-4c13-845b-1563941c37ee" />

<td>
<img width="801" alt="image" src="https://github.com/user-attachments/assets/61064943-abc9-4107-b320-f505e71e692d" />

</table>