### PR TITLE
Replace `logging` with `print` and defer `json` for faster import

### DIFF
--- a/src/norwegianblue/__init__.py
+++ b/src/norwegianblue/__init__.py
@@ -6,13 +6,12 @@ https://endoflife.date/docs/api/
 from __future__ import annotations
 
 import datetime as dt
-import json
 import logging
 from functools import cache
 
 from termcolor import colored
 
-from . import _cache, _version
+from . import _version
 
 __version__ = _version.__version__
 
@@ -41,6 +40,8 @@ def norwegianblue(
     if product == "norwegianblue":
         from ._data import prefix, res
     else:
+        from . import _cache
+
         url = BASE_URL + product.lower() + ".json"
         cache_file = _cache.filename(url)
         logger.info("Human URL:\thttps://endoflife.date/%s", product.lower())
@@ -59,6 +60,8 @@ def norwegianblue(
 
     if not res:
         # No cache, or couldn't load cache
+        import json
+
         import urllib3
 
         r = urllib3.request(
@@ -85,6 +88,8 @@ def norwegianblue(
         _cache.save(cache_file, res)
 
     if format == "json":
+        import json
+
         return json.dumps(res)
 
     data: list[dict] = list(res)

--- a/src/norwegianblue/__init__.py
+++ b/src/norwegianblue/__init__.py
@@ -6,12 +6,16 @@ https://endoflife.date/docs/api/
 from __future__ import annotations
 
 import datetime as dt
-import logging
+import sys
 from functools import cache
 
 from termcolor import colored
 
 from . import _version
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from typing import Any
 
 __version__ = _version.__version__
 
@@ -19,7 +23,13 @@ __all__ = ["__version__"]
 
 BASE_URL = "https://endoflife.date/api/"
 
-logger = logging.getLogger(__name__)
+_verbose = False
+
+
+def _print_verbose(*args: Any, **kwargs: Any) -> None:
+    """Print to stderr if verbose"""
+    if _verbose:
+        print(*args, file=sys.stderr, **kwargs)
 
 
 def error_404_text(product: str, suggestion: str) -> str:
@@ -44,18 +54,17 @@ def norwegianblue(
 
         url = BASE_URL + product.lower() + ".json"
         cache_file = _cache.filename(url)
-        logger.info("Human URL:\thttps://endoflife.date/%s", product.lower())
-        logger.info("API URL:\t%s", url)
-        logger.info(
+        _print_verbose(f"Human URL:\thttps://endoflife.date/{product.lower()}")
+        _print_verbose(f"API URL:\t{url}")
+        _print_verbose(
             "Source URL:\thttps://github.com/endoflife-date/endoflife.date/"
-            "blob/master/products/%s.md",
-            product.lower(),
+            f"blob/master/products/{product.lower()}.md",
         )
-        logger.info("Cache file:\t%s", cache_file)
+        _print_verbose(f"Cache file:\t{cache_file}")
 
         res = []
         if cache_file.is_file():
-            logger.info("Cache file exists")
+            _print_verbose("Cache file exists")
             res = _cache.load(cache_file)
 
     if not res:
@@ -71,7 +80,7 @@ def norwegianblue(
             redirect=True,
         )
 
-        logger.info("HTTP status code: %d", r.status)
+        _print_verbose("HTTP status code:", r.status)
         if r.status == 404:
             suggestion = suggest_product(product)
             msg = error_404_text(product, suggestion)
@@ -108,7 +117,7 @@ def norwegianblue(
         data = linkify(data, format)
 
     output = _tabulate(data, format, color, product if show_title else None)
-    logger.info("")
+    _print_verbose("")
 
     if product == "norwegianblue":
         return prefix + output
@@ -151,7 +160,7 @@ def suggest_product(product: str) -> str:
 
     # Find the closest match
     result = difflib.get_close_matches(product, all_products(), n=1)
-    logger.info("Suggestion:\t%s (score: %d)", *result)
+    _print_verbose("Suggestion:", result[0] if result else "")
     return result[0] if result else ""
 
 

--- a/src/norwegianblue/_cache.py
+++ b/src/norwegianblue/_cache.py
@@ -5,7 +5,6 @@ Cache functions
 from __future__ import annotations
 
 import datetime as dt
-import json
 from pathlib import Path
 
 from platformdirs import user_cache_dir
@@ -27,6 +26,8 @@ def load(cache_file: Path):
     if not cache_file.exists():
         return {}
 
+    import json
+
     with cache_file.open("r") as f:
         try:
             data = json.load(f)
@@ -38,6 +39,8 @@ def load(cache_file: Path):
 
 def save(cache_file: Path, data) -> None:
     """Save data to cache_file"""
+    import json
+
     try:
         if not CACHE_DIR.exists():
             CACHE_DIR.mkdir(parents=True)

--- a/src/norwegianblue/cli.py
+++ b/src/norwegianblue/cli.py
@@ -16,7 +16,6 @@ from __future__ import annotations
 
 import argparse
 import atexit
-import logging
 import platform
 import sys
 
@@ -71,10 +70,7 @@ def main() -> None:
     parser.add_argument(
         "-v",
         "--verbose",
-        action="store_const",
-        dest="loglevel",
-        const=logging.INFO,
-        default=logging.WARNING,
+        action="store_true",
         help="print extra messages to stderr",
     )
     parser.add_argument(
@@ -113,7 +109,7 @@ def main() -> None:
         argcomplete.autocomplete(parser)
     args = parser.parse_args()
 
-    logging.basicConfig(level=args.loglevel, format="%(message)s")
+    norwegianblue._verbose = args.verbose
     if args.clear_cache:
         _cache.clear(clear_all=True)
 


### PR DESCRIPTION
It's hard to avoid using `json` for real use (fetching fresh or cached data) but it saves a bit of time if you're importing `norwegianblue` and doing nothing else with it.

Also replace `logging` with `print` for verbose CLI output.

<table>
<tr>
<th>Before: 14 ms
<th>Defer json: 11 ms
<th>Replace logging: 2 ms
<tr>
<td valign="top">
<img width="2405" height="1898" alt="image" src="https://github.com/user-attachments/assets/770e586a-8c86-4a95-88d5-7bed5e8ded23" />

<td valign="top">
<img width="2405" height="1696" alt="image" src="https://github.com/user-attachments/assets/f36dd937-7639-43df-8d78-a210c2ee8cd8" />

<td valign="top">
<img width="2405" height="1292" alt="image" src="https://github.com/user-attachments/assets/b73bb8b8-0456-4332-bc2d-f86136212295" />

</table>